### PR TITLE
Use package instead of applicationId inside resource rule

### DIFF
--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -4,6 +4,6 @@
 
     <instrumentation
         android:name="android.support.test.runner.AndroidJUnitRunner"
-        android:targetPackage="com.uber.okbuck.example.test" />
+        android:targetPackage="com.uber.okbuck.example" />
 
 </manifest>

--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -4,6 +4,6 @@
 
     <instrumentation
         android:name="android.support.test.runner.AndroidJUnitRunner"
-        android:targetPackage="com.uber.okbuck.example" />
+        android:targetPackage="com.uber.okbuck.example.demo.debug" />
 
 </manifest>

--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -4,6 +4,6 @@
 
     <instrumentation
         android:name="android.support.test.runner.AndroidJUnitRunner"
-        android:targetPackage="com.uber.okbuck.example.demo.debug" />
+        android:targetPackage="com.uber.okbuck.example.test" />
 
 </manifest>

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/AndroidResourceRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/AndroidResourceRuleComposer.groovy
@@ -26,6 +26,6 @@ final class AndroidResourceRuleComposer extends AndroidBuckRuleComposer {
         }
 
         return new AndroidResourceRule(resLocal(resBundle), ["PUBLIC"], resDeps,
-                target.applicationId, resBundle.resDir, resBundle.assetsDir)
+                target.package, resBundle.resDir, resBundle.assetsDir)
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/AndroidResourceRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/AndroidResourceRuleComposer.groovy
@@ -26,6 +26,6 @@ final class AndroidResourceRuleComposer extends AndroidBuckRuleComposer {
         }
 
         return new AndroidResourceRule(resLocal(resBundle), ["PUBLIC"], resDeps,
-                target.package, resBundle.resDir, resBundle.assetsDir)
+                AndroidTarget.getPackage(target.project), resBundle.resDir, resBundle.assetsDir)
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/AndroidResourceRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/AndroidResourceRuleComposer.groovy
@@ -26,6 +26,6 @@ final class AndroidResourceRuleComposer extends AndroidBuckRuleComposer {
         }
 
         return new AndroidResourceRule(resLocal(resBundle), ["PUBLIC"], resDeps,
-                AndroidTarget.getPackage(target.project), resBundle.resDir, resBundle.assetsDir)
+                target.packageName, resBundle.resDir, resBundle.assetsDir)
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/AndroidTarget.groovy
@@ -262,6 +262,7 @@ abstract class AndroidTarget extends JavaLibTarget {
             GPathResult manifestXml = slurper.parse(project.file(mergedManifest))
 
             packageName = manifestXml.@package
+            manifestXml.@package = applicationId + applicationIdSuffix
 
             if (versionCode) {
                 manifestXml.@'android:versionCode' = String.valueOf(versionCode)


### PR DESCRIPTION
The `package` element inside main `AndroidManifest.xml` specifies the package `R.java`, the `applicationId` may be different for different flavors, but `package` is always the same.

I'm happy to change the implementation, wanted to get something working first.