### PR TITLE
Fix buck wrapper CUSTOM_BUCK_REPO on OSX

### DIFF
--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/wrapper/BUCKW_TEMPLATE
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/wrapper/BUCKW_TEMPLATE
@@ -44,7 +44,12 @@ ensure ( ) {
 
 md5digest ( ) {
     # only md5 is available by default on osx, while md5sum is available on other *nix systems
-    ( ensure md5sum && md5sum $1 ) || ( ensure md5 && md5 $1 )
+    unamestr=$(uname)
+    if [[ "$unamestr" == 'Darwin' ]]; then
+        ensure md5 && md5 $1
+    else
+        ensure md5sum && md5sum $1
+    fi
 }
 
 jsonq() {


### PR DESCRIPTION
the `md5digest` function was adding leading blank lines and spaces to the hash
on OSX, causing the `CUSTOM_BUCK_REPO` override to not work, since 
`git remote add` would reject a name with newlines.

Paired on it with @seanabraham