### PR TITLE
Download sources if enabled even if IDE plugins are not applied

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/Scope.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/Scope.groovy
@@ -11,6 +11,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.UnknownConfigurationException
+import org.gradle.plugins.ide.internal.IdeDependenciesExtractor
 
 @EqualsAndHashCode
 class Scope {
@@ -47,9 +48,11 @@ class Scope {
     }
 
     private void extractConfigurations(Collection<String> configurations) {
+        List<Configuration> validConfigurations = []
         configurations.each { String configName ->
             try {
                 Configuration configuration = project.configurations.getByName(configName)
+                validConfigurations.add(configuration)
                 Set<File> resolvedFiles = [] as Set
                 configuration.resolvedConfiguration.resolvedArtifacts.each { ResolvedArtifact artifact ->
                     String identifier = artifact.id.componentIdentifier.displayName
@@ -80,6 +83,11 @@ class Scope {
                 }
             } catch (UnknownConfigurationException ignored) {
             }
+        }
+
+        // Download sources if enabled
+        if (depCache.fetchSources) {
+            new IdeDependenciesExtractor().extractRepoFileDependencies(project.dependencies, validConfigurations, [], true, false)
         }
     }
 }


### PR DESCRIPTION
Gradle does not download sources by default. This means locally the IDE plugins that are applied by the android gradle plugin are responsible for downloading sources.

This has several problems
- If you only use buck generated project files, the sources are never downloaded by intellij as the `idea` plugin is not applied
- More importantly, the cache rule keys will be different locally and on CI causing the network cache to miss on all prebuilts

This change uses the same mechanism used by the gradle `idea` plugin to force sources to be downloaded to the local gradle cache so that the dependency cache can pick them up for the generated BUCK files when `sources` are enabled