### PR TITLE
Android Lint Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
   - mv buildSrc notBuildSrc
   - buck query "kind('android_binary', '//...')" | xargs buck build
   - buck test --include unit
+  - buck query "filter('lint_*', kind('genrule', '//...'))" | xargs buck build
   - android-wait-for-emulator
   - adb shell input keyevent 82
   - buck test //app:instrumentation_demoDebug_test

--- a/another-app/build.gradle
+++ b/another-app/build.gradle
@@ -24,6 +24,10 @@ android {
 
         test.setRoot('test')
     }
+
+    lintOptions {
+        disable 'HardcodedDebugMode'
+    }
 }
 
 dependencies {

--- a/buckw
+++ b/buckw
@@ -4,7 +4,7 @@
 ##
 ##  Buck wrapper script to invoke okbuck when needed, before running buck
 ##
-##  Created by OkBuck Gradle Plugin on : Mon Oct 10 12:58:03 PDT 2016
+##  Created by OkBuck Gradle Plugin on : Sun Nov 06 00:35:21 PDT 2016
 ##
 #########################################################################
 
@@ -93,7 +93,8 @@ getChanges ( ) {
         ["anyof",
             ["imatch", "**/*.gradle", "wholename"],
             ["imatch", "**/src/**/AndroidManifest.xml", "wholename"],
-            ["imatch", "**/gradle-wrapper.properties", "wholename"]
+            ["imatch", "**/gradle-wrapper.properties", "wholename"],
+            ["imatch", "**/lint.xml", "wholename"]
         ]
     ],
     "fields": ["name"]
@@ -128,11 +129,12 @@ runOkBuck ( ) {
     if [[ ! -z "$INSTALLED_WATCHMAN" ]]; then
         getToClean | jsonq '"\n".join(obj["files"])' | xargs rm
         info "DELETED OLD BUCK FILES"
-        EXTRA_ARGS="-xokbuckClean"
+        EXTRA_OKBUCK_ARGS="-xokbuckClean $EXTRA_OKBUCK_ARGS"
     fi
 
     rm -f $OKBUCK_SUCCESS
-    ( $WORKING_DIR/gradlew -p $WORKING_DIR okbuck -Dokbuck.wrapper=true $EXTRA_ARGS --stacktrace && updateOkBuckSuccess && success "PROCEEDING WITH BUCK" ) || die "OKBUCK FAILED"
+    ( $WORKING_DIR/gradlew -p $WORKING_DIR okbuck -Dokbuck.wrapper=true $EXTRA_OKBUCK_ARGS --stacktrace &&
+    updateOkBuckSuccess && success "PROCEEDING WITH BUCK" ) || die "OKBUCK FAILED"
 }
 
 watchmanWorkflow ( ) {

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,10 @@ def addCommonConfigurationForAndroidModules(Project project) {
                 targetCompatibility JavaVersion.VERSION_1_7
             }
         }
+
+        lintOptions {
+            lintConfig project.rootProject.file('config/lint/lint.xml')
+        }
     }
     if (project.plugins.hasPlugin('com.android.application')) {
         project.android {
@@ -138,6 +142,10 @@ if (project.file("buildSrc").exists()) {
 
         gradleGen {
             options = ["--offline", "-Dorg.gradle.configureondemand=true", "-Dorg.gradle.parallel=true"]
+        }
+
+        experimental {
+            lint = true
         }
     }
 

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/AndroidLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/AndroidLibraryRuleComposer.groovy
@@ -1,6 +1,5 @@
 package com.uber.okbuck.composer
 
-import com.uber.okbuck.constant.BuckConstants
 import com.uber.okbuck.core.model.AndroidLibTarget
 import com.uber.okbuck.core.model.AndroidTarget
 import com.uber.okbuck.core.model.Target

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/AndroidTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/AndroidTestRuleComposer.groovy
@@ -1,6 +1,5 @@
 package com.uber.okbuck.composer
 
-import com.uber.okbuck.constant.BuckConstants
 import com.uber.okbuck.core.model.AndroidLibTarget
 import com.uber.okbuck.core.model.AndroidTarget
 import com.uber.okbuck.core.model.Target

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/ExopackageAndroidLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/ExopackageAndroidLibraryRuleComposer.groovy
@@ -1,6 +1,5 @@
 package com.uber.okbuck.composer
 
-import com.uber.okbuck.constant.BuckConstants
 import com.uber.okbuck.core.model.AndroidAppTarget
 import com.uber.okbuck.generator.RetroLambdaGenerator
 import com.uber.okbuck.printable.PostProcessClassessCommands

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/JavaBuckRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/JavaBuckRuleComposer.groovy
@@ -19,4 +19,8 @@ abstract class JavaBuckRuleComposer extends BuckRuleComposer {
     static String aptJar(JavaTarget target) {
         return "apt_jar_${target.name}"
     }
+
+    static String lint(JavaTarget target) {
+        return "lint_${target.name}"
+    }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/JavaLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/JavaLibraryRuleComposer.groovy
@@ -1,6 +1,5 @@
 package com.uber.okbuck.composer
 
-import com.uber.okbuck.constant.BuckConstants
 import com.uber.okbuck.core.model.JavaLibTarget
 import com.uber.okbuck.generator.RetroLambdaGenerator
 import com.uber.okbuck.printable.PostProcessClassessCommands

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/JavaTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/JavaTestRuleComposer.groovy
@@ -1,6 +1,5 @@
 package com.uber.okbuck.composer
 
-import com.uber.okbuck.constant.BuckConstants
 import com.uber.okbuck.core.model.JavaLibTarget
 import com.uber.okbuck.generator.RetroLambdaGenerator
 import com.uber.okbuck.printable.PostProcessClassessCommands

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/LintRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/LintRuleComposer.groovy
@@ -1,0 +1,45 @@
+package com.uber.okbuck.composer
+
+import com.uber.okbuck.core.model.JavaTarget
+import com.uber.okbuck.core.model.Target
+import com.uber.okbuck.core.util.LintUtil
+import com.uber.okbuck.extension.LintExtension
+import com.uber.okbuck.generator.LintWrapperGenerator
+import com.uber.okbuck.rule.LintRule
+
+final class LintRuleComposer extends JavaBuckRuleComposer {
+
+    private LintRuleComposer() {
+        // no instance
+    }
+
+    static LintRule compose(JavaTarget target) {
+        Set<String> inputs = []
+        if (target.lintOptions.lintConfig != null && target.lintOptions.lintConfig.exists()) {
+            inputs.add(LintUtil.getLintwConfigRule(target.project, target.lintOptions.lintConfig))
+        }
+
+        LintExtension lintExtension = target.rootProject.okbuck.lint
+        LintWrapperGenerator.generate(target, lintExtension.jvmArgs)
+
+        Set<String> customLintTargets = [] as Set
+        Set<Target> lintJarTargets = target.lint.targetDeps.findAll {
+            (it instanceof JavaTarget) && (it.hasLintRegistry())
+        }
+
+        customLintTargets.addAll(targets(lintJarTargets))
+        customLintTargets.addAll(external(target.main.packagedLintJars))
+
+        Set<String> lintDeps = [] as Set
+        lintDeps.addAll(LintUtil.LINT_DEPS_RULE)
+        lintDeps.addAll(targets(lintJarTargets))
+
+        return new LintRule(
+                lint(target),
+                inputs,
+                LintUtil.getLintwRule(target),
+                customLintTargets,
+                lintDeps,
+                target.main.sources.empty ? null : ":${src(target)}")
+    }
+}

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/InValidDependencyException.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/InValidDependencyException.groovy
@@ -1,0 +1,8 @@
+package com.uber.okbuck.core.dependency
+
+class InValidDependencyException extends IllegalStateException {
+
+    InValidDependencyException(String msg) {
+        super(msg)
+    }
+}

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/AndroidTarget.groovy
@@ -6,6 +6,7 @@ import com.android.build.gradle.api.UnitTestVariant
 import com.android.build.gradle.internal.api.TestedVariant
 import com.android.build.gradle.internal.variant.BaseVariantData
 import com.android.builder.model.ClassField
+import com.android.builder.model.LintOptions
 import com.android.builder.model.SourceProvider
 import com.android.manifmerger.ManifestMerger2
 import com.android.manifmerger.MergingReport
@@ -124,6 +125,11 @@ abstract class AndroidTarget extends JavaLibTarget {
             }
         }
         return tasks
+    }
+
+    @Override
+    LintOptions getLintOptions() {
+        return project.android.lintOptions
     }
 
     Set<String> getSrcDirNames() {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/JavaTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/JavaTarget.groovy
@@ -1,5 +1,8 @@
 package com.uber.okbuck.core.model
 
+import com.android.builder.model.LintOptions
+import com.uber.okbuck.OkBuckGradlePlugin
+import com.uber.okbuck.core.util.LintUtil
 import org.apache.commons.io.IOUtils
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
@@ -32,6 +35,27 @@ abstract class JavaTarget extends Target {
             target.getProp(okbuck.annotationProcessors, null) != null
         })
         return aptScope
+    }
+
+    /**
+     * Lint Scope
+     */
+    Scope getLint() {
+        File res = null
+        Set<File> sourceDirs = []
+        List<String> jvmArguments = []
+        return new Scope(project, [OkBuckGradlePlugin.BUCK_LINT], sourceDirs, res, jvmArguments,
+                LintUtil.getLintCache(project))
+    }
+
+    LintOptions getLintOptions() {
+        return null
+    }
+
+    boolean hasLintRegistry() {
+        try {
+            return project.jar.manifest.attributes.containsKey("Lint-Registry")
+        } catch (Exception ignored) { }
     }
 
     /**
@@ -84,5 +108,6 @@ abstract class JavaTarget extends Target {
         getApt()
         getMain()
         getTest()
+        getLint()
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/Target.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/Target.groovy
@@ -1,7 +1,7 @@
 package com.uber.okbuck.core.model
 
-import com.uber.okbuck.extension.OkBuckExtension
 import com.uber.okbuck.core.util.FileUtil
+import com.uber.okbuck.extension.OkBuckExtension
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 import org.gradle.api.Project

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/util/FileUtil.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/util/FileUtil.groovy
@@ -8,14 +8,13 @@ final class FileUtil {
         // no instance
     }
 
-    static String getRelativePath(File rootDir, File dir) {
-        String rootPath = rootDir.absolutePath
-        String path = dir.absolutePath
+    static String getRelativePath(File root, File f) {
+        String rootPath = root.absolutePath
+        String path = f.absolutePath
         if (path.indexOf(rootPath) == 0) {
             return path.substring(rootPath.length() + 1)
         } else {
-            throw new IllegalArgumentException("sub dir ${dir.name} must " +
-                    "locate inside resourcesDir dir ${rootDir.name}")
+            throw new IllegalArgumentException("${f.name} must be located inside ${root.name}")
         }
     }
 

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/util/LintUtil.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/util/LintUtil.groovy
@@ -1,0 +1,124 @@
+package com.uber.okbuck.core.util
+
+import com.uber.okbuck.OkBuckGradlePlugin
+import com.uber.okbuck.core.dependency.DependencyCache
+import com.uber.okbuck.core.model.JavaTarget
+import com.uber.okbuck.core.model.Scope
+import org.apache.commons.io.FileUtils
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.ResolvedArtifact
+
+import java.nio.file.Files
+
+class LintUtil {
+
+    static final String LINT_GROUP = "com.android.tools.lint"
+    static final String LINT_MODULE = "lint"
+    static final String LINTW_LOCATION = ".okbuck/lintw"
+    static final String LINTW_BUCK_FILE = "lint/LINTW_BUCK_FILE"
+    static final String LINTW_TEMPLATE = "lint/LINTW_TEMPLATE"
+    static final File LINTW_BUCK = new File("${LINTW_LOCATION}/BUCK")
+
+    static final String LINT_DEPS_CONFIG = "${OkBuckGradlePlugin.BUCK_LINT}_deps"
+    static final String LINT_DEPS_CACHE = "${OkBuckGradlePlugin.DEFAULT_CACHE_PATH}/lintDeps"
+    static final String LINT_DEPS_RULE = "//${LINT_DEPS_CACHE}:okbuck_lint_deps"
+    static final String LINT_DEPS_BUCK_FILE = "lint/LINT_DEPS_BUCK_FILE"
+
+    static final String LINT_CACHE = "${OkBuckGradlePlugin.DEFAULT_CACHE_PATH}/lint"
+
+    private LintUtil() {}
+
+    static String getDefaultLintVersion(Project project) {
+        ResolvedArtifact lintArtifact = project.buildscript.configurations.classpath.resolvedConfiguration
+                .resolvedArtifacts.find {
+            ResolvedArtifact artifact ->
+                ModuleVersionIdentifier identifier = artifact.moduleVersion.id
+                return (identifier.group == LINT_GROUP && identifier.name == LINT_MODULE)
+        }
+        if (lintArtifact) {
+            return lintArtifact.moduleVersion.id.version
+        } else {
+            return null
+        }
+    }
+
+    static void fetchLintDeps(Project project, String version) {
+        if (!version) {
+            throw new IllegalStateException("Invalid lint jar version: ${version}")
+        }
+
+        project.configurations.maybeCreate(LINT_DEPS_CONFIG)
+        project.dependencies {
+            "${LINT_DEPS_CONFIG}" "${LINT_GROUP}:${LINT_MODULE}:${version}"
+        }
+
+        File res = null
+        Set<File> sourceDirs = []
+        List<String> jvmArguments = []
+        Scope lintDepsScope = new Scope(project, [LINT_DEPS_CONFIG], sourceDirs, res, jvmArguments,
+                getLintDepsCache(project))
+        lintDepsScope.getExternalDeps()
+    }
+
+    static File createLintw(JavaTarget target) {
+        File lintw = new File(target.rootProject.projectDir, getLintwPath(target))
+        lintw.parentFile.mkdirs()
+        lintw.createNewFile()
+
+        FileUtil.copyResourceToProject(LINTW_TEMPLATE, lintw)
+        if (!LINTW_BUCK.exists()) {
+            FileUtil.copyResourceToProject(LINTW_BUCK_FILE, LINTW_BUCK)
+        }
+        return lintw
+    }
+
+    static String getLintwScriptName(JavaTarget target) {
+        return "lintw_${target.identifier.replaceAll(':', '_')}_${target.name}"
+    }
+
+    static String getLintwPath(JavaTarget target) {
+        return "${LINTW_LOCATION}/${getLintwScriptName(target)}"
+    }
+
+    static String getLintwRule(JavaTarget target) {
+        return "//${LINTW_LOCATION}:${getLintwScriptName(target)}"
+    }
+
+    static String getLintwConfigName(Project project, File config) {
+        return FileUtil.getRelativePath(project.rootDir, config).replaceAll('/', '_')
+    }
+
+    static String getLintwConfigRule(Project project, File config) {
+        File configFile = new File("${LINTW_LOCATION}/${getLintwConfigName(project, config)}")
+        if (!configFile.exists() || !FileUtils.contentEquals(configFile, config)) {
+            if (configFile.exists()) {
+                configFile.delete()
+            } else {
+                configFile.parentFile.mkdirs()
+            }
+            Files.copy(config.toPath(), configFile.toPath())
+        }
+        return "//${LINTW_LOCATION}:${getLintwConfigName(project, config)}"
+    }
+
+    static DependencyCache getLintCache(Project project) {
+        return new DependencyCache(project.rootProject, LINT_CACHE) {
+
+            @Override
+            boolean isValid(File dep) {
+                return dep.name.endsWith(".jar")
+            }
+        }
+    }
+
+    static DependencyCache getLintDepsCache(Project project) {
+        return new DependencyCache(project.rootProject, LINT_DEPS_CACHE, false, LINT_DEPS_BUCK_FILE) {
+
+            @Override
+            boolean isValid(File dep) {
+                return dep.name.endsWith(".jar")
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/util/ProjectUtil.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/util/ProjectUtil.groovy
@@ -4,13 +4,13 @@ import com.android.build.gradle.AppPlugin
 import com.android.build.gradle.LibraryPlugin
 import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.BaseVariantOutput
-import com.uber.okbuck.extension.OkBuckExtension
 import com.uber.okbuck.core.model.AndroidAppTarget
 import com.uber.okbuck.core.model.AndroidLibTarget
 import com.uber.okbuck.core.model.JavaAppTarget
 import com.uber.okbuck.core.model.JavaLibTarget
 import com.uber.okbuck.core.model.ProjectType
 import com.uber.okbuck.core.model.Target
+import com.uber.okbuck.extension.OkBuckExtension
 import org.apache.commons.io.FilenameUtils
 import org.gradle.api.Project
 import org.gradle.api.plugins.ApplicationPlugin

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/util/RobolectricUtil.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/util/RobolectricUtil.groovy
@@ -50,8 +50,9 @@ class RobolectricUtil {
         File res = null
         Set<File> sourceDirs = []
         List<String> jvmArguments = []
+        String buckFile = null
         runtimeDeps.each { Configuration configuration ->
-            DependencyCache cache = new DependencyCache(project, ROBOLECTRIC_CACHE, false, false, false)
+            DependencyCache cache = new DependencyCache(project, ROBOLECTRIC_CACHE, false, buckFile)
             Scope runtimeDepsScope = new Scope(project, [configuration.name], sourceDirs, res, jvmArguments, cache)
             runtimeDepsScope.getExternalDeps()
         }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/extension/ExperimentalExtension.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/extension/ExperimentalExtension.groovy
@@ -3,4 +3,10 @@ package com.uber.okbuck.extension
 import com.uber.okbuck.core.annotation.Experimental
 
 @Experimental
-class ExperimentalExtension {}
+class ExperimentalExtension {
+
+    /**
+     * Whether lint rules are to be generated
+     */
+    boolean lint = false
+}

--- a/buildSrc/src/main/groovy/com/uber/okbuck/extension/LintExtension.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/extension/LintExtension.groovy
@@ -1,0 +1,28 @@
+package com.uber.okbuck.extension
+
+import com.uber.okbuck.core.annotation.Experimental
+import com.uber.okbuck.core.util.LintUtil
+import org.gradle.api.Project
+
+@Experimental
+class LintExtension {
+
+    /**
+     * Lint jar version
+     */
+    String version
+
+    /**
+     * List of rule types for which lint rules should be generated
+     */
+    Set<String> include = ['android_library'] as Set
+
+    /**
+     * JVM arguments when invoking lint
+     */
+    String jvmArgs = "-Xmx1024m"
+
+    LintExtension(Project project) {
+        version = LintUtil.getDefaultLintVersion(project)
+    }
+}

--- a/buildSrc/src/main/groovy/com/uber/okbuck/extension/WrapperExtension.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/extension/WrapperExtension.groovy
@@ -20,7 +20,7 @@ class WrapperExtension {
     /**
      * List of changed files to trigger okbuck runs on
      */
-    List<String> watch = ["**/*.gradle", "**/src/**/AndroidManifest.xml", "**/gradle-wrapper.properties"]
+    List<String> watch = ["**/*.gradle", "**/src/**/AndroidManifest.xml", "**/gradle-wrapper.properties", "**/lint.xml"]
 
     /**
      * List of added/removed directories to trigger okbuck runs on

--- a/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
@@ -1,7 +1,5 @@
 package com.uber.okbuck.generator
 
-import com.uber.okbuck.extension.GradleGenExtension
-import com.uber.okbuck.extension.OkBuckExtension
 import com.uber.okbuck.composer.AndroidBinaryRuleComposer
 import com.uber.okbuck.composer.AndroidBuckRuleComposer
 import com.uber.okbuck.composer.AndroidBuildConfigRuleComposer
@@ -20,6 +18,7 @@ import com.uber.okbuck.composer.JavaBinaryRuleComposer
 import com.uber.okbuck.composer.JavaLibraryRuleComposer
 import com.uber.okbuck.composer.JavaTestRuleComposer
 import com.uber.okbuck.composer.KeystoreRuleComposer
+import com.uber.okbuck.composer.LintRuleComposer
 import com.uber.okbuck.composer.PreBuiltNativeLibraryRuleComposer
 import com.uber.okbuck.composer.ZipRuleComposer
 import com.uber.okbuck.config.BUCKFile
@@ -32,6 +31,10 @@ import com.uber.okbuck.core.model.JavaLibTarget
 import com.uber.okbuck.core.model.ProjectType
 import com.uber.okbuck.core.model.Target
 import com.uber.okbuck.core.util.ProjectUtil
+import com.uber.okbuck.extension.ExperimentalExtension
+import com.uber.okbuck.extension.GradleGenExtension
+import com.uber.okbuck.extension.LintExtension
+import com.uber.okbuck.extension.OkBuckExtension
 import com.uber.okbuck.extension.TestExtension
 import com.uber.okbuck.rule.AndroidLibraryRule
 import com.uber.okbuck.rule.AndroidManifestRule
@@ -209,9 +212,14 @@ final class BuckFileGenerator {
                     appClass))
         }
 
+        ExperimentalExtension experimental = okbuck.experimental
+        LintExtension lint = okbuck.lint
+        if (experimental.lint && lint.include.contains('android_library')) {
+            androidLibRules.add(LintRuleComposer.compose(target))
+        }
+
         rules.addAll(androidLibRules)
         return rules
-
     }
 
     private static List<BuckRule> createRules(AndroidAppTarget target) {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/generator/DotBuckConfigLocalGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/generator/DotBuckConfigLocalGenerator.groovy
@@ -1,12 +1,12 @@
 package com.uber.okbuck.generator
 
-import com.uber.okbuck.extension.OkBuckExtension
 import com.uber.okbuck.composer.AndroidBuckRuleComposer
 import com.uber.okbuck.config.DotBuckConfigLocalFile
 import com.uber.okbuck.core.model.AndroidAppTarget
 import com.uber.okbuck.core.model.ProjectType
 import com.uber.okbuck.core.model.Target
 import com.uber.okbuck.core.util.ProjectUtil
+import com.uber.okbuck.extension.OkBuckExtension
 import org.gradle.api.Project
 
 final class DotBuckConfigLocalGenerator {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/generator/LintWrapperGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/generator/LintWrapperGenerator.groovy
@@ -1,0 +1,81 @@
+package com.uber.okbuck.generator
+
+import com.uber.okbuck.core.model.AndroidTarget
+import com.uber.okbuck.core.model.JavaTarget
+import com.uber.okbuck.core.util.LintUtil
+
+public class LintWrapperGenerator {
+
+    private LintWrapperGenerator() {
+        // no instance
+    }
+
+    static String generate(JavaTarget target, String lintJvmArgs) {
+        File lintw = LintUtil.createLintw(target)
+        String outputText = lintw.text
+        outputText = outputText.replaceFirst('template-jvmArgs', lintJvmArgs)
+        StringBuilder sb = new StringBuilder(outputText)
+
+        if (!target.main.sources.empty) {
+            sb.append(toCmd('--classpath "$MODULE_JAR"'))
+        }
+        if (target.lintOptions.abortOnError) {
+            sb.append(toCmd("--exitcode"))
+        }
+        if (target.lintOptions.absolutePaths) {
+            sb.append(toCmd("--fullpath"))
+        }
+        if (target.lintOptions.quiet) {
+            sb.append(toCmd("--quiet"))
+        }
+        if (target.lintOptions.checkAllWarnings) {
+            sb.append(toCmd("-Wall"))
+        }
+        if (target.lintOptions.ignoreWarnings) {
+            sb.append(toCmd("--nowarn"))
+        }
+        if (target.lintOptions.warningsAsErrors) {
+            sb.append(toCmd("-Werror"))
+        }
+        if (target.lintOptions.noLines) {
+            sb.append(toCmd("--nolines"))
+        }
+        if (target.lintOptions.disable) {
+            sb.append(toCmd("--disable ${target.lintOptions.disable.join(',')}"))
+        }
+        if (target.lintOptions.enable) {
+            sb.append(toCmd("--enable ${target.lintOptions.enable.join(',')}"))
+        }
+        if (target.lintOptions.lintConfig && target.lintOptions.lintConfig.exists()) {
+            sb.append(toCmd("--config ${target.lintOptions.lintConfig.absolutePath}"))
+        }
+        if (target.lintOptions.xmlReport) {
+            sb.append(toCmd('--xml "${OUTPUT_DIR}/lint-results.xml"'))
+        }
+        if (target.lintOptions.htmlReport) {
+            sb.append(toCmd('--html "${OUTPUT_DIR}/lint-results.html"'))
+        }
+        target.main.sources.each { String sourceDir ->
+            sb.append(toCmd("--sources ${new File(target.project.projectDir, sourceDir).absolutePath}"))
+        }
+        if (target instanceof AndroidTarget) {
+            target.getResources().each { AndroidTarget.ResBundle bundle ->
+                if (bundle.resDir) {
+                    sb.append(toCmd("--resources ${new File(target.project.projectDir, bundle.resDir).absolutePath}"))
+                }
+            }
+
+            // Project root is at okbuck generated manifest for this target
+            sb.append(toCmd("${new File(target.project.projectDir, target.manifest).parentFile.absolutePath}"))
+        }
+
+        lintw.text = sb.toString()
+        lintw.setExecutable(true)
+
+        return lintw.absolutePath
+    }
+
+    private static String toCmd(String option) {
+        return "    ${option} \\\n"
+    }
+}

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/LintRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/LintRule.groovy
@@ -1,0 +1,61 @@
+package com.uber.okbuck.rule
+
+final class LintRule extends BuckRule {
+
+    static final String SEPARATOR = ':'
+
+    private final String lintw
+    private final Set<String> inputs
+    private final Set<String> customLintTargets
+    private final Set<String> lintDeps
+    private final String lintTarget
+
+    LintRule(String name,
+             Set<String> inputs,
+             String lintw,
+             Set<String> customLintTargets,
+             Set<String> lintDeps,
+             String lintTarget) {
+        super("genrule", name)
+        this.lintw = lintw
+        this.inputs = inputs
+        this.customLintTargets = customLintTargets
+        this.lintDeps = lintDeps
+        this.lintTarget = lintTarget
+    }
+
+    @Override
+    final void printContent(PrintStream printer) {
+        if (!inputs.empty) {
+            printer.println("\tsrcs = [")
+            for (String input : inputs) {
+                printer.println("\t\t'${input}',")
+            }
+            printer.println("\t],")
+        }
+        printer.println("\tout = '${name}_out',")
+        printer.println("\tbash = 'mkdir -p \$OUT; LINT_DEPS=${toClasspath(lintDeps)} ' \\")
+        printer.println("\t'ANDROID_LINT_JARS=${toLocation(customLintTargets)} ' \\")
+        if (lintTarget) {
+            printer.println("\t'MODULE_JAR=${toLocation(lintTarget)} ' \\")
+        }
+        printer.println("\t'OUTPUT_DIR=\$OUT ' \\")
+        printer.println("\t'${toLocation(lintw)}',")
+    }
+
+    static String toClasspath(Set<String> targets) {
+        return (targets.collect { toClasspath(it) } as Set).join(SEPARATOR)
+    }
+
+    static String toLocation(Set<String> targets) {
+        return (targets.collect { toLocation(it) } as Set).join(SEPARATOR)
+    }
+
+    static String toClasspath(String target) {
+        return "\$(classpath ${target})"
+    }
+
+    static String toLocation(String target) {
+        return "\$(location ${target})"
+    }
+}

--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/lint/LINTW_BUCK_FILE
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/lint/LINTW_BUCK_FILE
@@ -1,0 +1,16 @@
+import re
+
+file_name_regex = re.compile(r'^.*/([^/]+)$', re.IGNORECASE)
+files = []
+
+for file in glob(['*']):
+  name = file_name_regex.sub(r'\1', file)
+  files.append(name)
+
+files.remove('BUCK')
+
+for file in files:
+  export_file(
+    name = file,
+    visibility = ['PUBLIC'],
+  )

--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/lint/LINTW_TEMPLATE
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/lint/LINTW_TEMPLATE
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+exec java \
+    template-jvmArgs \
+    -Djava.awt.headless=true \
+    -classpath "$LINT_DEPS" \
+    com.android.tools.lint.Main \

--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/lint/LINT_DEPS_BUCK_FILE
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/lint/LINT_DEPS_BUCK_FILE
@@ -1,0 +1,22 @@
+import re
+
+file_name_regex = re.compile(r'^.*/([^/]+)\.(jar)$', re.IGNORECASE)
+
+jars = []
+
+for jar in glob(['*.jar']):
+  name = file_name_regex.sub(r'\1', jar)
+  jars.append(name)
+
+for jar in jars:
+  prebuilt_jar(
+    name = jar,
+    binary_jar = jar,
+    visibility = ['PUBLIC'],
+  )
+
+java_library(
+  name='okbuck_lint_deps',
+  deps=map(lambda x: ":" + x, jars),
+  visibility = ['PUBLIC'],
+)

--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/wrapper/BUCKW_TEMPLATE
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/wrapper/BUCKW_TEMPLATE
@@ -42,11 +42,6 @@ ensure ( ) {
     command -v $1 >/dev/null 2>&1 || die "ERROR: '$1' could be found in your PATH. Please install $1. $2"
 }
 
-md5digest ( ) {
-    # only md5 is available by default on osx, while md5sum is available on other *nix systems
-    ( ensure md5sum && md5sum $1 ) || ( ensure md5 && md5 $1 )
-}
-
 jsonq() {
     python -c "import sys,json; obj=json.load(sys.stdin); print($1)"
 }
@@ -128,11 +123,11 @@ runOkBuck ( ) {
     if [[ ! -z "$INSTALLED_WATCHMAN" ]]; then
         getToClean | jsonq '"\n".join(obj["files"])' | xargs rm
         info "DELETED OLD BUCK FILES"
-        EXTRA_ARGS="-xokbuckClean"
+        EXTRA_OKBUCK_ARGS="-xokbuckClean $EXTRA_OKBUCK_ARGS"
     fi
 
     rm -f $OKBUCK_SUCCESS
-    ( $WORKING_DIR/gradlew -p $WORKING_DIR okbuck -Dokbuck.wrapper=true $EXTRA_ARGS $EXTRA_OKBUCK_ARGS --stacktrace &&
+    ( $WORKING_DIR/gradlew -p $WORKING_DIR okbuck -Dokbuck.wrapper=true $EXTRA_OKBUCK_ARGS --stacktrace &&
     updateOkBuckSuccess && success "PROCEEDING WITH BUCK" ) || die "OKBUCK FAILED"
 }
 

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="HardcodedDebugMode" severity="ignore"/>
+</lint>

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ def versions = [
 ]
 
 def build = [
-        androidPlugin    : 'com.android.tools.build:gradle:2.2.1',
+        androidPlugin    : 'com.android.tools.build:gradle:2.2.2',
         androidAptPlugin : 'com.neenbedankt.gradle.plugins:android-apt:1.8',
         butterKnifePlugin: "com.jakewharton:butterknife-gradle-plugin:${versions.butterKnifeVersion}",
         retrolambdaPlugin: 'me.tatarka:gradle-retrolambda:3.3.0',

--- a/libraries/common/build.gradle
+++ b/libraries/common/build.gradle
@@ -23,5 +23,4 @@ dependencies {
 
     testCompile deps.test.junit
     testCompile project(':libraries:robolectric-base')
-
 }

--- a/libraries/emptylibrary/build.gradle
+++ b/libraries/emptylibrary/build.gradle
@@ -1,6 +1,12 @@
 apply plugin: 'com.android.library'
 apply plugin: 'me.tatarka.retrolambda'
 
+android {
+    lintOptions {
+        disable 'HardcodedDebugMode'
+    }
+}
+
 dependencies {
     compile deps.support.appCompat
 }


### PR DESCRIPTION
- Adds support for generating `lint_*` `genrule`s for `android_library` targets
- Hooks are in place to let lint rules be generated for any jvm library targets. Theoretically lint can be run on java, kotlin or scala etc with some small tweaks. Lint can also be run on test sources with a few small tweaks as well. These changes will be part of a subsequent PR
- Supports custom lint jars embedded in aars
- Supports custom lint project/external dependencies. For example, a java library that defines custom lint rules can be added to another library as a linter by making it a dependency of the `buckLint` configuration
- Fully incremental, parallel and buck cache/network cache friendly
- Supports many android dsl options specified in `lintOptions`
- Ability to pin lint api version and not be surprised when android gradle plugin pulls in new checks on updates
- Requires an updated `buckw` by running the `buckWrapper` to watch for changes to `lint.xml` files and run `okbuck` again as needed
- Lint on all android rules can be run like `buck query "filter('lint_*', kind('genrule', '//...'))" | xargs buck build`