### PR TITLE
Bundle lint dependencies into a fat jar

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/BuckRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/BuckRuleComposer.groovy
@@ -6,13 +6,31 @@ abstract class BuckRuleComposer {
 
     static Set<String> external(Set<String> deps) {
         return deps.collect { String dep ->
-            "//${dep.reverse().replaceFirst("/", ":").reverse()}"
+            external(dep)
         }
+    }
+
+    static String external(String dep) {
+        return "//${dep.reverse().replaceFirst("/", ":").reverse()}"
     }
 
     static Set<String> targets(Set<Target> deps) {
         return deps.collect { Target targetDep ->
-            "//${targetDep.path}:src_${targetDep.name}"
+            targets(targetDep)
         }
+    }
+
+    static String targets(Target dep) {
+        return "//${dep.path}:src_${dep.name}"
+    }
+
+    static Set<String> binTargets(Set<Target> deps) {
+        return deps.collect { Target targetDep ->
+            binTargets(targetDep)
+        }
+    }
+
+    static String binTargets(Target dep) {
+        return "//${dep.path}:bin_${dep.name}"
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/JavaBinaryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/JavaBinaryRuleComposer.groovy
@@ -10,6 +10,6 @@ final class JavaBinaryRuleComposer extends JavaBuckRuleComposer {
     }
 
     static JavaBinaryRule compose(JavaAppTarget target) {
-        return new JavaBinaryRule(bin(target), ["PUBLIC"], [":${src(target)}"], target.mainClass)
+        return new JavaBinaryRule(bin(target), ["PUBLIC"], [":${src(target)}"], target.mainClass, target.excludes)
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/LintRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/LintRuleComposer.groovy
@@ -1,5 +1,6 @@
 package com.uber.okbuck.composer
 
+import com.uber.okbuck.core.model.JavaAppTarget
 import com.uber.okbuck.core.model.JavaTarget
 import com.uber.okbuck.core.model.Target
 import com.uber.okbuck.core.util.LintUtil
@@ -30,16 +31,25 @@ final class LintRuleComposer extends JavaBuckRuleComposer {
         customLintTargets.addAll(targets(lintJarTargets))
         customLintTargets.addAll(external(target.main.packagedLintJars))
 
-        Set<String> lintDeps = [] as Set
-        lintDeps.addAll(LintUtil.LINT_DEPS_RULE)
-        lintDeps.addAll(targets(lintJarTargets))
+        Set<String> classpathLintDeps = [] as Set
+        Set<String> locationLintDeps = [] as Set
+
+        locationLintDeps.addAll(LintUtil.LINT_DEPS_RULE)
+        lintJarTargets.each {
+            if (it instanceof JavaAppTarget) {
+                locationLintDeps.addAll(targets([it] as Set))
+            } else {
+                classpathLintDeps.addAll(targets([it] as Set))
+            }
+        }
 
         return new LintRule(
                 lint(target),
                 inputs,
                 LintUtil.getLintwRule(target),
                 customLintTargets,
-                lintDeps,
+                classpathLintDeps,
+                locationLintDeps,
                 target.main.sources.empty ? null : ":${src(target)}")
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/LintRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/LintRuleComposer.groovy
@@ -1,9 +1,10 @@
 package com.uber.okbuck.composer
 
-import com.uber.okbuck.core.model.JavaAppTarget
 import com.uber.okbuck.core.model.JavaTarget
+import com.uber.okbuck.core.model.ProjectType
 import com.uber.okbuck.core.model.Target
 import com.uber.okbuck.core.util.LintUtil
+import com.uber.okbuck.core.util.ProjectUtil
 import com.uber.okbuck.extension.LintExtension
 import com.uber.okbuck.generator.LintWrapperGenerator
 import com.uber.okbuck.rule.LintRule
@@ -28,18 +29,18 @@ final class LintRuleComposer extends JavaBuckRuleComposer {
             (it instanceof JavaTarget) && (it.hasLintRegistry())
         }
 
-        customLintTargets.addAll(targets(lintJarTargets))
         customLintTargets.addAll(external(target.main.packagedLintJars))
+        customLintTargets.addAll(targets(lintJarTargets))
 
         Set<String> classpathLintDeps = [] as Set
         Set<String> locationLintDeps = [] as Set
 
         locationLintDeps.addAll(LintUtil.LINT_DEPS_RULE)
         lintJarTargets.each {
-            if (it instanceof JavaAppTarget) {
-                locationLintDeps.addAll(targets([it] as Set))
+            if (ProjectUtil.getType(it.project) == ProjectType.JAVA_APP) {
+                locationLintDeps.addAll(binTargets(it))
             } else {
-                classpathLintDeps.addAll(targets([it] as Set))
+                classpathLintDeps.addAll(targets(it))
             }
         }
 

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/JavaAppTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/JavaAppTarget.groovy
@@ -4,13 +4,15 @@ import org.gradle.api.Project
 
 class JavaAppTarget extends JavaLibTarget {
 
-    static final String MAIN = "main"
-
     JavaAppTarget(Project project, String name) {
-        super(project, name);
+        super(project, name)
     }
 
     String getMainClass() {
         return project.hasProperty('mainClassName') ? project.mainClassName : null
+    }
+
+    Set<String> getExcludes() {
+        return project.jar.excludes as Set
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/JavaTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/JavaTarget.groovy
@@ -55,7 +55,9 @@ abstract class JavaTarget extends Target {
     boolean hasLintRegistry() {
         try {
             return project.jar.manifest.attributes.containsKey("Lint-Registry")
-        } catch (Exception ignored) { }
+        } catch (Exception ignored) {
+            return false
+        }
     }
 
     /**

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/util/ProjectUtil.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/util/ProjectUtil.groovy
@@ -87,6 +87,7 @@ final class ProjectUtil {
                         }
                     }
                     break
+                case ProjectType.JAVA_APP:
                 case ProjectType.JAVA_LIB:
                     result = new JavaLibTarget(project, JavaLibTarget.MAIN)
                     break

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/JavaBinaryRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/JavaBinaryRule.groovy
@@ -3,16 +3,29 @@ package com.uber.okbuck.rule
 final class JavaBinaryRule extends BuckRule {
 
     private final String mMainClass
+    private final Set<String> mExcludes
 
-    JavaBinaryRule(String name, List<String> visibility, List<String> deps, String mainClass) {
+    JavaBinaryRule(String name,
+                   List<String> visibility,
+                   List<String> deps,
+                   String mainClass,
+                   Set<String> excludes = []) {
         super("java_binary", name, visibility, deps)
         mMainClass = mainClass
+        mExcludes = excludes
     }
 
     @Override
     protected final void printContent(PrintStream printer) {
         if (mMainClass) {
             printer.println("\tmain_class = '${mMainClass}',")
+        }
+        if (!mExcludes.empty) {
+            printer.println("\tblacklist = [")
+            for (String exclude : mExcludes) {
+                printer.println("\t\t'${exclude}',")
+            }
+            printer.println("\t],")
         }
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/LintRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/LintRule.groovy
@@ -7,20 +7,23 @@ final class LintRule extends BuckRule {
     private final String lintw
     private final Set<String> inputs
     private final Set<String> customLintTargets
-    private final Set<String> lintDeps
+    private final Set<String> classpathLintDeps
+    private final Set<String> locationLintDeps
     private final String lintTarget
 
     LintRule(String name,
              Set<String> inputs,
              String lintw,
              Set<String> customLintTargets,
-             Set<String> lintDeps,
+             Set<String> classpathLintDeps,
+             Set<String> locationLintDeps,
              String lintTarget) {
         super("genrule", name)
         this.lintw = lintw
         this.inputs = inputs
         this.customLintTargets = customLintTargets
-        this.lintDeps = lintDeps
+        this.classpathLintDeps = classpathLintDeps
+        this.locationLintDeps = locationLintDeps
         this.lintTarget = lintTarget
     }
 
@@ -33,14 +36,23 @@ final class LintRule extends BuckRule {
             }
             printer.println("\t],")
         }
+
+        String lintDeps = [toClasspath(classpathLintDeps), toLocation(locationLintDeps)].findAll {
+            !it.empty
+        }.join(SEPARATOR)
+
         printer.println("\tout = '${name}_out',")
-        printer.println("\tbash = 'mkdir -p \$OUT; LINT_DEPS=${toClasspath(lintDeps)} ' \\")
-        printer.println("\t'ANDROID_LINT_JARS=${toLocation(customLintTargets)} ' \\")
+        printer.println("\tbash = 'mkdir -p \$OUT; export LINT_DEPS=${lintDeps} ; ' \\")
+        printer.println("\t'export ANDROID_LINT_JARS=${toLocation(customLintTargets)} ; ' \\")
         if (lintTarget) {
-            printer.println("\t'MODULE_JAR=${toLocation(lintTarget)} ' \\")
+            printer.println("\t'export MODULE_JAR=${toLocation(lintTarget)} ; ' \\")
         }
-        printer.println("\t'OUTPUT_DIR=\$OUT ' \\")
+        printer.println("\t'export OUTPUT_DIR=\$OUT ; ' \\")
         printer.println("\t'${toLocation(lintw)}',")
+    }
+
+    static String toLintDeps(Set<String> targets) {
+        return (targets.collect { toClasspath(it) } as Set).join(SEPARATOR)
     }
 
     static String toClasspath(Set<String> targets) {

--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/lint/LINT_DEPS_BUCK_FILE
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/lint/LINT_DEPS_BUCK_FILE
@@ -15,8 +15,12 @@ for jar in jars:
     visibility = ['PUBLIC'],
   )
 
-java_library(
+java_binary(
   name='okbuck_lint_deps',
   deps=map(lambda x: ":" + x, jars),
+  blacklist=[
+    'META-INF',
+    'org.jetbrains.annotations',
+  ],
   visibility = ['PUBLIC'],
 )


### PR DESCRIPTION
Lint has many dependencies and with a bunch of custom lint targets, it can lead to "Argument list too long" error when running the lint genrules.

To avoid this all, android sdk lint dependencies are converted to a fat jar before being provided to the command line linter. Custom lint gradle modules can apply the java `application` gradle plugin to be bundled up into a fat jar as well. When doing so, you may want to add

```gradle
jar {
    excludes = 'META-INF'
}
```

To such modules to avoid weird lint exceptions with jar signing verifications