### PR TITLE
Add support for test runner jvm args

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ subprojects { project ->
                 || project.plugins.hasPlugin('com.android.library')) {
             addCommonConfigurationForAndroidModules(project)
         }
+
+        project.tasks.withType(Test) { Test task ->
+            task.jvmArgs << "-Djava.awt.headless=true"
+        }
     }
 }
 

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/AndroidTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/AndroidTestRuleComposer.groovy
@@ -72,6 +72,7 @@ final class AndroidTestRuleComposer extends AndroidBuckRuleComposer {
                 target.targetCompatibility,
                 postprocessClassesCommands,
                 target.test.jvmArgs,
+                target.testRunnerJvmArgs,
                 target.test.resourcesDir,
                 RobolectricUtil.ROBOLECTRIC_CACHE)
     }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/JavaTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/JavaTestRuleComposer.groovy
@@ -52,6 +52,7 @@ final class JavaTestRuleComposer extends JavaBuckRuleComposer {
                 target.sourceCompatibility,
                 target.targetCompatibility,
                 postprocessClassesCommands,
-                target.test.jvmArgs)
+                target.test.jvmArgs,
+                target.testRunnerJvmArgs)
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/AndroidTarget.groovy
@@ -5,6 +5,7 @@ import com.android.build.gradle.api.TestVariant
 import com.android.build.gradle.api.UnitTestVariant
 import com.android.build.gradle.internal.api.TestedVariant
 import com.android.build.gradle.internal.variant.BaseVariantData
+import com.android.builder.core.VariantType
 import com.android.builder.model.ClassField
 import com.android.builder.model.LintOptions
 import com.android.builder.model.SourceProvider
@@ -20,6 +21,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.logging.Logger
 import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.api.tasks.testing.Test
 
 /**
  * An Android target
@@ -156,6 +158,14 @@ abstract class AndroidTarget extends JavaLibTarget {
     @Override
     String getInitialBootCp() {
         return baseVariant.javaCompile.options.bootClasspath
+    }
+
+    @Override
+    List<String> getTestRunnerJvmArgs() {
+        Test testTask = project.tasks.withType(Test).find {
+            it.name == "${VariantType.UNIT_TEST.prefix}${name.capitalize()}${VariantType.UNIT_TEST.suffix}" as String
+        }
+        return testTask != null ? testTask.allJvmArgs : []
     }
 
     List<String> getBuildConfigFields() {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/JavaTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/JavaTarget.groovy
@@ -1,11 +1,13 @@
 package com.uber.okbuck.core.model
 
+import com.android.builder.core.VariantType
 import com.android.builder.model.LintOptions
 import com.uber.okbuck.OkBuckGradlePlugin
 import com.uber.okbuck.core.util.LintUtil
 import org.apache.commons.io.IOUtils
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
 
 import java.util.jar.JarEntry
 import java.util.jar.JarFile
@@ -86,6 +88,16 @@ abstract class JavaTarget extends Target {
      */
     Set<GradleSourceGen> getGradleSourcegen() {
         return [] as Set
+    }
+
+    /**
+     * List of test jvm args
+     */
+    List<String> getTestRunnerJvmArgs() {
+        Test testTask = project.tasks.withType(Test).find {
+            it.name == "test"
+        }
+        return testTask != null ? testTask.allJvmArgs : []
     }
 
     protected static String javaVersion(JavaVersion version) {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/AndroidLibraryRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/AndroidLibraryRule.groovy
@@ -46,6 +46,7 @@ final class AndroidLibraryRule extends AndroidRule {
                 targetCompatibility,
                 postprocessClassesCommands,
                 options,
+                null,
                 generateR2,
                 null,
                 null,

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/AndroidRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/AndroidRule.groovy
@@ -17,6 +17,7 @@ abstract class AndroidRule extends BuckRule {
     private final String mTargetCompatibility
     private final PostProcessClassessCommands mPostprocessClassesCommands
     private final List<String> mOptions
+    private final List<String> mTestRunnerJvmArgs
     private final Set<String> mProvidedDeps
     private final boolean mGenerateR2
     private final String mResourcesDir
@@ -46,6 +47,7 @@ abstract class AndroidRule extends BuckRule {
             String targetCompatibility,
             PostProcessClassessCommands postprocessClassesCommands,
             List<String> options,
+            List<String> testRunnerJvmArgs,
             boolean generateR2,
             String resourcesDir,
             String runtimeDependency,
@@ -65,6 +67,7 @@ abstract class AndroidRule extends BuckRule {
         mTargetCompatibility = targetCompatibility
         mPostprocessClassesCommands = postprocessClassesCommands
         mOptions = options
+        mTestRunnerJvmArgs = testRunnerJvmArgs
         mProvidedDeps = providedDeps
         mGenerateR2 = generateR2
         mResourcesDir = resourcesDir
@@ -174,6 +177,14 @@ abstract class AndroidRule extends BuckRule {
             printer.println("\tlabels = [")
             mLabels.each { String label ->
                 printer.println("\t\t'${label}',")
+            }
+            printer.println("\t],")
+        }
+
+        if (mTestRunnerJvmArgs) {
+            printer.println("\tvm_args = [")
+            mTestRunnerJvmArgs.each { String arg ->
+                printer.println("\t\t'${arg}',")
             }
             printer.println("\t],")
         }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/AndroidTestRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/AndroidTestRule.groovy
@@ -25,6 +25,7 @@ final class AndroidTestRule extends AndroidRule {
             String targetCompatibility,
             PostProcessClassessCommands postprocessClassesCommands,
             List<String> options,
+            List<String> testRunnerJvmArgs,
             String mResourcesDir,
             String runtimeDependency) {
 
@@ -46,6 +47,7 @@ final class AndroidTestRule extends AndroidRule {
                 targetCompatibility,
                 postprocessClassesCommands,
                 options,
+                testRunnerJvmArgs,
                 false,
                 mResourcesDir,
                 runtimeDependency,

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/JavaLibraryRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/JavaLibraryRule.groovy
@@ -33,6 +33,7 @@ final class JavaLibraryRule extends JavaRule {
                 targetCompatibility,
                 postprocessClassesCommands,
                 options,
+                null,
                 testTargets)
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/JavaRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/JavaRule.groovy
@@ -12,6 +12,7 @@ abstract class JavaRule extends BuckRule {
     private final String mTargetCompatibility
     private final PostProcessClassessCommands mPostprocessClassesCommands
     private final List<String> mOptions
+    private final List<String> mTestRunnerJvmArgs
     private final Set<String> mProvidedDeps
     private final List<String> mTestTargets
     private final List<String> mLabels
@@ -30,6 +31,7 @@ abstract class JavaRule extends BuckRule {
             String targetCompatibility,
             PostProcessClassessCommands postprocessClassesCommands,
             List<String> options,
+            List<String> testRunnerJvmArgs,
             List<String> testTargets,
             List<String> labels = null) {
 
@@ -42,6 +44,7 @@ abstract class JavaRule extends BuckRule {
         mResourcesDir = resourcesDir
         mPostprocessClassesCommands = postprocessClassesCommands
         mOptions = options
+        mTestRunnerJvmArgs = testRunnerJvmArgs
         mProvidedDeps = providedDeps
         mTestTargets = testTargets
         mLabels = labels
@@ -113,6 +116,14 @@ abstract class JavaRule extends BuckRule {
             printer.println("\tlabels = [")
             mLabels.each { String label ->
                 printer.println("\t\t'${label}',")
+            }
+            printer.println("\t],")
+        }
+
+        if (mTestRunnerJvmArgs) {
+            printer.println("\tvm_args = [")
+            mTestRunnerJvmArgs.each { String arg ->
+                printer.println("\t\t'${arg}',")
             }
             printer.println("\t],")
         }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/JavaTestRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/JavaTestRule.groovy
@@ -16,7 +16,8 @@ final class JavaTestRule extends JavaRule {
             String sourceCompatibility,
             String targetCompatibility,
             PostProcessClassessCommands postprocessClassesCommands,
-            List<String> options) {
+            List<String> options,
+            List<String> testRunnerJvmArgs) {
         super(
                 "java_test",
                 name,
@@ -31,6 +32,7 @@ final class JavaTestRule extends JavaRule {
                 targetCompatibility,
                 postprocessClassesCommands,
                 options,
+                testRunnerJvmArgs,
                 null,
                 ['unit', 'java'])
     }


### PR DESCRIPTION
This supports test jvm args set in gradle like

```
project.tasks.withType(Test) { Test task ->
    task.jvmArgs << "-Djava.awt.headless=true"
}
```

so that buck tests do not pop up a java icon in the dock for every test vm created