### PR TITLE
Do not invoke retrolambda with empty inputDir

### DIFF
--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/retrolambda/retrolambdac
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/retrolambda/retrolambdac
@@ -27,21 +27,21 @@ if [[ $TRAPPED_EXIT_CODE == 0 ]]; then # If javac succeeded
     esac
     shift
     done
-
-    # Get script directory
-    prog="$0"
-    while [ -h "${prog}" ]; do
-        newProg=`/bin/ls -ld "${prog}"`
-        newProg=`expr "${newProg}" : ".* -> \(.*\)$"`
-        if expr "x${newProg}" : 'x/' >/dev/null; then
-            prog="${newProg}"
-        else
-            progdir=`dirname "${prog}"`
-            prog="${progdir}/${newProg}"
-        fi
-    done
-    DIR=`dirname $prog`
-    if [ -n "$OUTPUT_DIR" ]; then
+    # Skip retrolambda completely if there are no files to be processed
+    if [[ ! -z "$OUTPUT_DIR" ]]; then
+      # Get script directory
+      prog="$0"
+      while [ -h "${prog}" ]; do
+          newProg=`/bin/ls -ld "${prog}"`
+          newProg=`expr "${newProg}" : ".* -> \(.*\)$"`
+          if expr "x${newProg}" : 'x/' >/dev/null; then
+              prog="${newProg}"
+          else
+              progdir=`dirname "${prog}"`
+              prog="${progdir}/${newProg}"
+          fi
+      done
+      DIR=`dirname $prog`
       # Run retrolambda on the output classes
       java -Dretrolambda.inputDir="${OUTPUT_DIR}" \
       -Dretrolambda.classpath="${BOOT_CLASSPATH}":"${CLASSPATH}":"${OUTPUT_DIR}" \

--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/retrolambda/retrolambdac
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/retrolambda/retrolambdac
@@ -41,11 +41,12 @@ if [[ $TRAPPED_EXIT_CODE == 0 ]]; then # If javac succeeded
         fi
     done
     DIR=`dirname $prog`
-
-    # Run retrolambda on the output classes
-    java -Dretrolambda.inputDir="${OUTPUT_DIR}" \
-    -Dretrolambda.classpath="${BOOT_CLASSPATH}":"${CLASSPATH}":"${OUTPUT_DIR}" \
-    template-retrolambda-jvm-args -jar "${DIR}"/template-retrolambda-jar
+    if [ -n "$OUTPUT_DIR" ]; then
+      # Run retrolambda on the output classes
+      java -Dretrolambda.inputDir="${OUTPUT_DIR}" \
+      -Dretrolambda.classpath="${BOOT_CLASSPATH}":"${CLASSPATH}":"${OUTPUT_DIR}" \
+      template-retrolambda-jvm-args -jar "${DIR}"/template-retrolambda-jar
+    fi
 else
     exit $TRAPPED_EXIT_CODE # Exit with javac exit code if failure
 fi


### PR DESCRIPTION
This bug caused a major breakage in our CI server after upgrading to okbuck 0.10.

The symptom is that builds started failing with `ResourceParseException premature end of file`, or `file not found` or any similar errors.

After SSHing into the server I could observe that several files were modified after running buck build, always random files under the same directory, mostly just `.java` or `.xml` files (which was the majority of the files in the directory). I could verify this by running `git status`. For every modified file, it would almost always be completely empty (all contents deleted) or sometimes partially deleted (more rarely). 
I also observed that the list of deleted files was always different and the longer the build ran, the more files were deleted.

After a lot of digging, I think I was able to finally pinpoint the issue by verifying that some `java` processes had open file handles to several directories in many levels deep in our source code during `buck build`. I also noticed that these processes all looked like this:

```
java -Dretrolambda.inputDir= -Dretrolambda.classpath=:/mnt/TeamCity/.gradle/caches/okbuck/buck/build/bootstrapper/bootstrapper.jar: -jar /mnt/TeamCity/agents/buildAgent/work/74094ff6a628c9a2/android/.okbuck/cache/retrolambda/retrolambda-2.3.0.jar
```

You can see that `retrolambda.inputDir` is empty, which looks suspicious. My guess was that buck called `javac` with no input files (there was no changed files to be compiled maybe) and that caused the `OUTPUT_DIR` variable to be empty, which was passed into `retrolambda.inputDir`.

After briefly looking into the Retrolambda [source code](https://github.com/orfjackal/retrolambda/blob/master/retrolambda/src/main/java/net/orfjackal/retrolambda/Retrolambda.java#L92), I could verify that it indeed walks the tree based on the `inputDir` variable and writes files. This could also be a retrolambda bug since it definitely shouldn't delete all the files contents, but anyways by simply skipping it, the problem seems to be resolved, so here we are 😄 