### PR TITLE
Add option to generate BUCK files in parallel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,6 +158,7 @@ okbuck {
     experimental {
         lint = true
         retrolambda = true
+        parallel = true
     }
     wrapper {
         repo = "https://github.com/kageiit/buck.git"

--- a/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
@@ -150,8 +150,9 @@ class OkBuckGradlePlugin implements Plugin<Project> {
         IOUtils.closeQuietly(configPrinter)
 
         ExperimentalExtension experimental = okbuck.experimental
-        if (!experimental.parallel) {
-            okbuck.buckProjects.each { Project subProject ->
+        okbuck.buckProjects.each { Project subProject ->
+            BuckFileGenerator.resolve(subProject)
+            if (!experimental.parallel) {
                 BuckFileGenerator.generate(subProject)
             }
         }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/DependencyCache.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/DependencyCache.groovy
@@ -1,6 +1,7 @@
 package com.uber.okbuck.core.dependency
 
 import com.uber.okbuck.core.util.FileUtil
+import groovy.transform.Synchronized
 import org.apache.commons.io.FileUtils
 import org.gradle.api.Project
 
@@ -8,6 +9,7 @@ import java.nio.file.FileSystem
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
 
 class DependencyCache {
 
@@ -20,7 +22,7 @@ class DependencyCache {
 
     private Map<VersionlessDependency, String> finalDepFiles = [:]
     private Map<VersionlessDependency, String> lintJars = [:]
-    private Map<VersionlessDependency, ExternalDependency> greatestVersions = [:]
+    private Map<VersionlessDependency, ExternalDependency> greatestVersions = new ConcurrentHashMap()
 
     DependencyCache(Project rootProject,
                     String cacheDirPath,
@@ -50,6 +52,7 @@ class DependencyCache {
         }
     }
 
+    @Synchronized
     String get(ExternalDependency dependency) {
         ExternalDependency greatestVersion = greatestVersions.get(dependency)
         if (!finalDepFiles.containsKey(greatestVersion)) {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/util/FileUtil.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/util/FileUtil.groovy
@@ -1,5 +1,6 @@
 package com.uber.okbuck.core.util
 
+import groovy.transform.Memoized
 import org.gradle.api.Project
 
 final class FileUtil {
@@ -8,6 +9,7 @@ final class FileUtil {
         // no instance
     }
 
+    @Memoized
     static String getRelativePath(File root, File f) {
         String rootPath = root.absolutePath
         String path = f.absolutePath

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/util/ProjectUtil.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/util/ProjectUtil.groovy
@@ -11,6 +11,7 @@ import com.uber.okbuck.core.model.java.JavaLibTarget
 import com.uber.okbuck.core.model.base.ProjectType
 import com.uber.okbuck.core.model.base.Target
 import com.uber.okbuck.core.model.jvm.JvmTarget
+import groovy.transform.Memoized
 import org.gradle.api.Project
 import org.gradle.api.plugins.ApplicationPlugin
 import org.gradle.api.plugins.GroovyPlugin
@@ -22,6 +23,7 @@ final class ProjectUtil {
         // no instance
     }
 
+    @Memoized
     static ProjectType getType(Project project) {
         if (project.plugins.hasPlugin(AppPlugin)) {
             return ProjectType.ANDROID_APP
@@ -38,6 +40,7 @@ final class ProjectUtil {
         }
     }
 
+    @Memoized
     static Map<String, Target> getTargets(Project project) {
         ProjectType type = getType(project)
         switch (type) {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/extension/ExperimentalExtension.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/extension/ExperimentalExtension.groovy
@@ -19,4 +19,9 @@ class ExperimentalExtension {
      * Whether transform rules are to be generated
      */
     boolean transform = false
+
+    /**
+     * Generate buck files per project in parallel sub tasks
+     */
+    boolean parallel = false
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
@@ -60,7 +60,6 @@ final class BuckFileGenerator {
      */
     static Map<Project, BUCKFile> generate(Project project) {
         OkBuckExtension okbuck = project.rootProject.okbuck
-        resolve(project)
 
         TestExtension test = okbuck.test
         List<BuckRule> rules = createRules(project, test.espresso)
@@ -73,7 +72,7 @@ final class BuckFileGenerator {
         }
     }
 
-    private static void resolve(Project project) {
+    static void resolve(Project project) {
         Map<String, Target> targets = getTargets(project)
 
         targets.each { String name, Target target ->


### PR DESCRIPTION
Adds an experimental `parallel` flag that lets okbuck generate BUCK files as a per project task. This can reduce okbuck run times when used in combination with gradle's parallel flag.