### PR TITLE
Clean up BUCK files if rm fails

### DIFF
--- a/buckw
+++ b/buckw
@@ -128,9 +128,13 @@ runOkBuck ( ) {
     echo
 
     if [[ ! -z "$INSTALLED_WATCHMAN" ]]; then
-        getToClean | jsonq '"\n".join(obj["files"])' | xargs rm
-        info "DELETED OLD BUCK FILES"
-        EXTRA_OKBUCK_ARGS="-xokbuckClean $EXTRA_OKBUCK_ARGS"
+        getToClean | jsonq '"\n".join(obj["files"])' | xargs aasdasd
+        if [[ $? -eq 0 ]]; then
+            info "DELETED OLD BUCK FILES"
+            EXTRA_OKBUCK_ARGS="-xokbuckClean $EXTRA_OKBUCK_ARGS"
+        else
+            warn "WATCHMAN FAILED. USING OKBUCKCLEAN."
+        fi
     fi
 
     rm -f $OKBUCK_SUCCESS


### PR DESCRIPTION
If the watchman query doesn't work out, we need to clean all buckfiles. Stale BUCK files can produce the following:

[1m[44m RUNNING OKBUCK... [0;10m

Traceback (most recent call last):
  File "<string>", line 1, in <module>
KeyError: 'files'
rm: missing operand
Try `rm --help' for more information.
[1m[44m DELETED OLD BUCK FILES [0;10m