### PR TITLE
Cleanup old files in dependency cache

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
@@ -106,6 +106,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
                         projectConfigurations,
                         EXTERNAL_DEP_BUCK_FILE,
                         true,
+                        true,
                         intellij.sources,
                         experimental.lint)
             }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/DependencyCache.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/DependencyCache.groovy
@@ -121,7 +121,13 @@ class DependencyCache {
 
         // cleanup
         if (cleanup) {
-            (rootProject.fileTree(dir: cacheDir, includes: ['*.jar', '*.aar']) - cachedCopies).each { File f ->
+            (cacheDir.listFiles(new FileFilter() {
+
+                @Override
+                boolean accept(File pathname) {
+                    return pathname.isFile() && (pathname.name.endsWith(".jar") || pathname.name.endsWith(".aar"))
+                }
+            }) - cachedCopies).each { File f ->
                 f.delete()
             }
         }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/util/RobolectricUtil.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/util/RobolectricUtil.groovy
@@ -50,7 +50,9 @@ class RobolectricUtil {
             new DependencyCache("robolectric${configuration.name.toUpperCase()}",
                     project,
                     ROBOLECTRIC_CACHE,
-                    [configuration] as Set)
+                    [configuration] as Set,
+                    null,
+                    false)
         }
     }
 }


### PR DESCRIPTION
Speeds up evaluation of buck rules by cleaning up unused dep files in various dependency caches