### PR TITLE
Improved Annotation Processor resolution

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/java/JavaTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/java/JavaTarget.groovy
@@ -59,21 +59,7 @@ abstract class JavaTarget extends JvmTarget {
      * List of annotation processor classes.
      */
     Set<String> getAnnotationProcessors() {
-        return (apt.externalDeps.collect { String aptDep ->
-            JarFile jar = new JarFile(rootProject.file(aptDep))
-            jar.entries().findAll { JarEntry entry ->
-                (entry.name == "META-INF/services/javax.annotation.processing.Processor")
-            }.collect { JarEntry aptEntry ->
-                IOUtils.toString(jar.getInputStream(aptEntry))
-                        .trim().split("\\n").findAll { String entry ->
-                    !entry.startsWith('#') && !entry.trim().empty // filter out comments and empty lines
-                }
-            }
-        } + apt.targetDeps.collect { Target target ->
-            (List<String>) target.getProp(okbuck.annotationProcessors, null)
-        }.findAll { List<String> processors ->
-            processors != null
-        }).flatten() as List<String>
+        return apt.getAnnotationProcessors()
     }
 
     protected static String javaVersion(JavaVersion version) {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/util/LintUtil.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/util/LintUtil.groovy
@@ -2,6 +2,7 @@ package com.uber.okbuck.core.util
 
 import com.uber.okbuck.OkBuckGradlePlugin
 import com.uber.okbuck.core.dependency.DependencyCache
+import groovy.transform.Synchronized
 import org.apache.commons.io.FileUtils
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ModuleVersionIdentifier
@@ -63,6 +64,7 @@ class LintUtil {
         return FileUtil.getRelativePath(project.rootDir, config).replaceAll('/', '_')
     }
 
+    @Synchronized
     static String getLintwConfigRule(Project project, File config) {
         File configFile = new File("${LINT_DEPS_CACHE}/${getLintwConfigName(project, config)}")
         if (!configFile.exists() || !FileUtils.contentEquals(configFile, config)) {


### PR DESCRIPTION
- Move annotation processor search to dependency cache and perform it lazily when a scope requests it
- Only check for annotation processors in jars that are first level module dependencies
Related to #274