### PR TITLE
Add a check to fail build on invalid local dependencies

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/Scope.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/Scope.groovy
@@ -13,6 +13,7 @@ import com.uber.okbuck.core.model.jvm.JvmTarget
 import com.uber.okbuck.core.util.FileUtil
 import com.uber.okbuck.core.util.ProjectUtil
 import groovy.transform.EqualsAndHashCode
+import org.apache.commons.io.FilenameUtils
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedArtifact
@@ -129,6 +130,11 @@ class Scope {
         files.findAll { File resolved ->
             !resolvedFiles.contains(resolved)
         }.each { File localDep ->
+            if (!FilenameUtils.directoryContains(project.rootProject.projectDir.absolutePath, localDep.absolutePath)) {
+                throw new IllegalStateException("Local dependencies should be under project root. Dependencies " +
+                        "outside the project can cause hard to reproduce builds. Please move dependency: ${localDep} " +
+                        "inside ${project.rootProject.projectDir}")
+            }
             external.add(ExternalDependency.fromLocal(localDep))
         }
     }


### PR DESCRIPTION
Added jdk tools jar to a project. Tested that `okbuck` failed

```
:libraries:common:okbuck FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':libraries:common:okbuck'.
> Local dependencies should be under project root. Dependencies outside the project can cause hard to reproduce builds. Please move dependency: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/lib/tools.jar inside /Users/kage/src/okbuck
```