### PR TITLE
Add genrule support for running infer.

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/InferRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/InferRuleComposer.groovy
@@ -1,0 +1,36 @@
+package com.uber.okbuck.composer.android
+
+import com.uber.okbuck.composer.java.JavaBuckRuleComposer
+import com.uber.okbuck.core.model.java.JavaTarget
+import com.uber.okbuck.rule.base.GenRule
+
+class InferRuleComposer extends JavaBuckRuleComposer {
+
+    private InferRuleComposer() {
+        // no instance
+    }
+
+    static GenRule compose(JavaTarget target) {
+        List<String> inferCmds = []
+        List<String> inputs = []
+        String sources = ""
+
+        inferCmds.add("mkdir -p \$OUT;")
+
+        target.main.sources.each { String sourceDir ->
+            sources += sourceDir + ":"
+            inputs.add(sourceDir)
+        }
+        if (sources.length() != 0) {
+            sources = sources.substring(0, (sources.length() - 1))
+        }
+
+        inferCmds.add("infer --fail-on-issue --results-dir \$OUT --sourcepath src --generated-classes ${toLocation(":${src(target)}")} --classpath \$(classpath :${src(target)}) -- genrule")
+
+        return new GenRule(
+                "infer_${target.name}",
+                inputs,
+                inferCmds
+        )
+    }
+}

--- a/buildSrc/src/main/groovy/com/uber/okbuck/extension/ExperimentalExtension.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/extension/ExperimentalExtension.groovy
@@ -11,6 +11,11 @@ class ExperimentalExtension {
     boolean lint = false
 
     /**
+     * Whether infer rules are to be generated
+     */
+    boolean infer = false
+
+    /**
      * Whether retrolambda is enabled
      */
     boolean retrolambda = false

--- a/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
@@ -10,6 +10,7 @@ import com.uber.okbuck.composer.android.AndroidLibraryRuleComposer
 import com.uber.okbuck.composer.android.AndroidManifestRuleComposer
 import com.uber.okbuck.composer.android.AndroidResourceRuleComposer
 import com.uber.okbuck.composer.android.AndroidTestRuleComposer
+import com.uber.okbuck.composer.android.InferRuleComposer
 import com.uber.okbuck.composer.android.ExopackageAndroidLibraryRuleComposer
 import com.uber.okbuck.composer.android.GenAidlRuleComposer
 import com.uber.okbuck.composer.android.KeystoreRuleComposer
@@ -113,8 +114,14 @@ final class BuckFileGenerator {
     }
 
     private static List<BuckRule> createRules(JavaLibTarget target) {
+        OkBuckExtension okbuck = target.rootProject.okbuck
+        ExperimentalExtension experimental = okbuck.experimental
         List<BuckRule> rules = []
         rules.add(JavaLibraryRuleComposer.compose(target))
+
+        if (experimental.infer) {
+            rules.add(InferRuleComposer.compose(target))
+        }
 
         if (target.test.sources) {
             rules.add(JavaTestRuleComposer.compose(target))
@@ -204,6 +211,10 @@ final class BuckFileGenerator {
         LintExtension lint = okbuck.lint
         if (experimental.lint && lint.include.contains('android_library')) {
             androidLibRules.add(LintRuleComposer.compose(target))
+        }
+
+        if (experimental.infer) {
+            rules.add(InferRuleComposer.compose(target))
         }
 
         rules.addAll(androidLibRules)


### PR DESCRIPTION
Only missing thing here is to pass the boot classpath to infer so it can correctly analyze the base classes like java.concurrent. 