### PR TITLE
Add extension to specify lint libraries.

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
@@ -46,6 +46,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
     public static final String DEFAULT_CACHE_PATH = ".okbuck/cache"
     public static final String GROUP = "okbuck"
     public static final String BUCK_LINT = "buckLint"
+    public static final String BUCK_LINT_LIBRARY = "buckLintLibrary"
     public static final String LINT = "lint"
     public static final String TRANSFORM = "transform"
     public static final String RETROLAMBDA = "retrolambda"
@@ -197,6 +198,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
     private static void configureBuckProjects(Set<Project> buckProjects, Task setupOkbuck) {
         buckProjects.each { Project buckProject ->
             buckProject.configurations.maybeCreate(BUCK_LINT)
+            buckProject.configurations.maybeCreate(BUCK_LINT_LIBRARY)
             Task okbuckProjectTask = buckProject.tasks.maybeCreate(OKBUCK)
             okbuckProjectTask.doLast {
                 BuckFileGenerator.generate(buckProject)

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/LintRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/LintRuleComposer.groovy
@@ -56,6 +56,14 @@ final class LintRuleComposer extends JvmBuckRuleComposer {
 
         if (!target.main.sources.empty) {
             lintCmds.add("--classpath ${toLocation(":${src(target)}")}")
+
+            Set<String> lintLibraries = []
+            lintLibraries = lintLibraries + target.lintLibraries.externalDeps
+            lintLibraries = lintLibraries + target.lintLibraries.targetDeps
+            if (!lintLibraries.isEmpty()) {
+                String libraries = lintLibraries.join(':')
+                lintCmds.add("--libraries ${libraries}")
+            }
         }
         if (target.lintOptions.abortOnError) {
             lintCmds.add("--exitcode")

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/java/JavaTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/java/JavaTarget.groovy
@@ -5,6 +5,7 @@ import com.uber.okbuck.OkBuckGradlePlugin
 import com.uber.okbuck.core.model.base.Scope
 import com.uber.okbuck.core.model.jvm.JvmTarget
 import com.uber.okbuck.core.util.LintUtil
+import com.uber.okbuck.core.util.ProjectUtil
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 
@@ -41,6 +42,16 @@ abstract class JavaTarget extends JvmTarget {
         List<String> jvmArguments = []
         return new Scope(project, [OkBuckGradlePlugin.BUCK_LINT], sourceDirs, res, jvmArguments,
                 LintUtil.getLintDepsCache(project))
+    }
+
+    /**
+     * Lint Scope
+     */
+    Scope getLintLibraries() {
+        File res = null
+        Set<File> sourceDirs = []
+        List<String> jvmArguments = []
+        return new Scope(project, [OkBuckGradlePlugin.BUCK_LINT_LIBRARY], sourceDirs, res, jvmArguments, ProjectUtil.getDependencyCache(project))
     }
 
     LintOptions getLintOptions() {


### PR DESCRIPTION
This allows you to modify what gets put on the libraries flag via gradle dsl. You can use the buckLintLibrary configuration to put a dependency on the linter --libraries.

```
dependencies {
     buckLintLibrary deps.uber.javaRx
 }
```

The above would make a libraries flag that would look like the following.

```
--libraries .okbuck/cache/com.ubercab.rx.java-0.11.1.jar:.okbuck/cache/com.ubercab.rx.irrelevant-0.11.1.jar:.okbuck/cache/com.android.support.support-annotations-25.0.1.jar:.okbuck/cache/io.reactivex.rxjava-1.2.5.jar 
```