### PR TITLE
Don't pass default values to Map.get to prevent map mutation.

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
@@ -180,7 +180,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
     }
 
     private static Set<Configuration> configurations(Set<Project> projects) {
-        Set<Configuration> configurations = new HashSet()
+        Set<Configuration> configurations = new HashSet() as Set<Configuration>
         projects.each { Project p ->
             TargetCache.getTargets(p).values().each {
                 if (it instanceof JavaLibTarget) {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/DependencyCache.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/DependencyCache.groovy
@@ -48,7 +48,7 @@ class DependencyCache {
         this.cacheDir = new File(rootProject.projectDir, cacheDirPath)
         this.cacheDir.mkdirs()
 
-        superConfiguration = createSuperConfiguration(rootProject, "${name}DepCache", configurations)
+        superConfiguration = createSuperConfiguration(rootProject, "${name}DepCache" as String, configurations)
 
         if (buckFile) {
             FileUtil.copyResourceToProject(buckFile, new File(cacheDir, "BUCK"))

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/ExternalDependency.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/ExternalDependency.groovy
@@ -33,9 +33,9 @@ class ExternalDependency extends VersionlessDependency {
     String getCacheName(boolean useFullDepName = false) {
         if (useFullDepName) {
             if (group) {
-                return "${group}.${depFile.name}"
+                return "${group}.${depFile.name}" as String
             } else {
-                return "${name}.${depFile.name}"
+                return "${name}.${depFile.name}" as String
             }
 
         } else {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidAppTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidAppTarget.groovy
@@ -44,10 +44,10 @@ class AndroidAppTarget extends AndroidLibTarget {
         }
 
         multidexEnabled = baseVariant.mergedFlavor.multiDexEnabled
-        primaryDexPatterns = getProp(okbuck().primaryDexPatterns, []) as Set<String>
-        linearAllocHardLimit = getProp(okbuck().linearAllocHardLimit, DEFAULT_LINEARALLOC_LIMIT) as Integer
+        primaryDexPatterns = getProp(okbuck.primaryDexPatterns, []) as Set<String>
+        linearAllocHardLimit = getProp(okbuck.linearAllocHardLimit, DEFAULT_LINEARALLOC_LIMIT) as Integer
 
-        exoPackageDependencies = getProp(okbuck().appLibDependencies, []) as Set<String>
+        exoPackageDependencies = getProp(okbuck.appLibDependencies, []) as Set<String>
 
         if (isTest) {
             placeholders.put('applicationId', applicationId - ".test" + applicationIdSuffix + ".test")
@@ -70,7 +70,7 @@ class AndroidAppTarget extends AndroidLibTarget {
     }
 
     ExoPackageScope getExopackage() {
-        if (getProp(okbuck().exopackage, false)) {
+        if (getProp(okbuck.exopackage, false)) {
             return new ExoPackageScope(project, main, exoPackageDependencies, manifest)
         } else {
             return null
@@ -124,11 +124,11 @@ class AndroidAppTarget extends AndroidLibTarget {
     }
 
     List<Map<String, String>> getTransforms() {
-        return (List<Map<String, String>>) getProp(okbuck().transform.transforms, [])
+        return (List<Map<String, String>>) getProp(okbuck.transform.transforms, [])
     }
 
     String getTransformRunnerClass() {
-        return okbuck().transform.main
+        return okbuck.transform.main
     }
 
     static String getPackedProguardConfig(File file) {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidAppTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidAppTarget.groovy
@@ -40,14 +40,14 @@ class AndroidAppTarget extends AndroidLibTarget {
         if (baseVariant.ndkCompile.abiFilters != null) {
             cpuFilters = baseVariant.ndkCompile.abiFilters
         } else {
-            cpuFilters = [] as Set
+            cpuFilters = [] as Set<String>
         }
 
         multidexEnabled = baseVariant.mergedFlavor.multiDexEnabled
-        primaryDexPatterns = getProp(okbuck.primaryDexPatterns, []) as Set
-        linearAllocHardLimit = getProp(okbuck.linearAllocHardLimit, DEFAULT_LINEARALLOC_LIMIT) as Integer
+        primaryDexPatterns = getProp(okbuck().primaryDexPatterns, []) as Set<String>
+        linearAllocHardLimit = getProp(okbuck().linearAllocHardLimit, DEFAULT_LINEARALLOC_LIMIT) as Integer
 
-        exoPackageDependencies = getProp(okbuck.appLibDependencies, []) as Set
+        exoPackageDependencies = getProp(okbuck().appLibDependencies, []) as Set<String>
 
         if (isTest) {
             placeholders.put('applicationId', applicationId - ".test" + applicationIdSuffix + ".test")
@@ -70,7 +70,7 @@ class AndroidAppTarget extends AndroidLibTarget {
     }
 
     ExoPackageScope getExopackage() {
-        if (getProp(okbuck.exopackage, false)) {
+        if (getProp(okbuck().exopackage, false)) {
             return new ExoPackageScope(project, main, exoPackageDependencies, manifest)
         } else {
             return null
@@ -83,7 +83,7 @@ class AndroidAppTarget extends AndroidLibTarget {
             mergedProguardConfig.parentFile.mkdirs()
             mergedProguardConfig.createNewFile()
 
-            Set<File> configs = [] as Set
+            Set<File> configs = [] as Set<File>
 
             // project proguard files
             configs.addAll(baseVariant.mergedFlavor.proguardFiles)
@@ -124,11 +124,11 @@ class AndroidAppTarget extends AndroidLibTarget {
     }
 
     List<Map<String, String>> getTransforms() {
-        return (List<Map<String, String>>) getProp(okbuck.transform.transforms, [])
+        return (List<Map<String, String>>) getProp(okbuck().transform.transforms, [])
     }
 
     String getTransformRunnerClass() {
-        return okbuck.transform.main
+        return okbuck().transform.main
     }
 
     static String getPackedProguardConfig(File file) {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidTarget.groovy
@@ -130,7 +130,7 @@ abstract class AndroidTarget extends JavaLibTarget {
     }
 
     boolean getRobolectric() {
-        return okbuck().test.robolectric
+        return okbuck.test.robolectric
     }
 
     @Override

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidTarget.groovy
@@ -130,7 +130,7 @@ abstract class AndroidTarget extends JavaLibTarget {
     }
 
     boolean getRobolectric() {
-        return rootProject.okbuck.test.robolectric
+        return okbuck().test.robolectric
     }
 
     @Override
@@ -209,8 +209,8 @@ abstract class AndroidTarget extends JavaLibTarget {
 
         Set<File> keys = (resourceMap.keySet() + assetMap.keySet())
         Set<ResBundle> resBundles = keys.collect { key ->
-            new ResBundle(key.name, resourceMap.get(key, null), assetMap.get(key, null))
-        } as Set
+            new ResBundle(key.name, resourceMap.get(key), assetMap.get(key))
+        } as Set<ResBundle>
 
         // Add an empty resource bundle even if no res and assets folders exist since we use resource_union
         if (resBundles.empty) {
@@ -387,10 +387,21 @@ abstract class AndroidTarget extends JavaLibTarget {
 
     @Override
     def getProp(Map map, defaultValue) {
-        return map.get("${identifier}${name.capitalize()}" as String,
-                map.get("${identifier}${flavor.capitalize()}" as String,
-                        map.get("${identifier}${buildType.capitalize()}" as String,
-                                map.get(identifier, defaultValue))))
+        String nameKey = "${identifier}${name.capitalize()}" as String
+        String flavorKey = "${identifier}${flavor.capitalize()}" as String
+        String buildTypeKey = "${identifier}${buildType.capitalize()}" as String
+
+        if (map.containsKey(nameKey)) {
+            return map.get(nameKey)
+        } else if (map.containsKey(flavorKey)) {
+            return map.get(flavorKey)
+        } else if (map.containsKey(buildTypeKey)) {
+            return map.get(buildTypeKey)
+        } else if (map.containsKey(identifier)) {
+            return map.get(identifier)
+        } else {
+            return defaultValue
+        }
     }
 
     private static class GradleLogger implements ILogger {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/Target.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/Target.groovy
@@ -44,7 +44,7 @@ abstract class Target {
         rootProject = project.gradle.rootProject
     }
 
-    OkBuckExtension okbuck() {
+    OkBuckExtension getOkbuck() {
         return rootProject.okbuck
     }
 
@@ -68,7 +68,7 @@ abstract class Target {
     }
 
     Set<String> getExtraOpts(RuleType ruleType) {
-        def propertyMap = getProp(okbuck().extraBuckOpts, [:])
+        def propertyMap = getProp(okbuck.extraBuckOpts, [:])
 
         if (propertyMap.containsKey(ruleType.name().toLowerCase())) {
             return propertyMap.get(ruleType.name().toLowerCase())

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/Target.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/Target.groovy
@@ -27,7 +27,6 @@ abstract class Target {
     final String name
     final String identifier
     final String path
-    final OkBuckExtension okbuck
 
     /**
      * Constructor.
@@ -43,7 +42,10 @@ abstract class Target {
         path = identifier.replaceAll(':', '/')
 
         rootProject = project.gradle.rootProject
-        okbuck = rootProject.okbuck
+    }
+
+    OkBuckExtension okbuck() {
+        return rootProject.okbuck
     }
 
     protected Set<String> getAvailable(Collection<File> files) {
@@ -55,10 +57,23 @@ abstract class Target {
     }
 
     def getProp(Map map, defaultValue) {
-        return map.get("${identifier}${name}", map.get(identifier, defaultValue))
+        String nameKey = "${identifier}${name}" as String
+        if (map.containsKey(nameKey)) {
+            return map.get(nameKey)
+        } else if (map.containsKey(identifier)) {
+            return map.get(identifier)
+        } else {
+            return defaultValue
+        }
     }
 
     Set<String> getExtraOpts(RuleType ruleType) {
-        return getProp(okbuck.extraBuckOpts, [:]).get(ruleType.name().toLowerCase(), [])
+        def propertyMap = getProp(okbuck().extraBuckOpts, [:])
+
+        if (propertyMap.containsKey(ruleType.name().toLowerCase())) {
+            return propertyMap.get(ruleType.name().toLowerCase())
+        } else {
+            return []
+        }
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/Target.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/Target.groovy
@@ -70,8 +70,9 @@ abstract class Target {
     Set<String> getExtraOpts(RuleType ruleType) {
         def propertyMap = getProp(okbuck.extraBuckOpts, [:])
 
-        if (propertyMap.containsKey(ruleType.name().toLowerCase())) {
-            return propertyMap.get(ruleType.name().toLowerCase())
+        String ruleTypeKey = ruleType.name().toLowerCase()
+        if (propertyMap.containsKey(ruleTypeKey)) {
+            return propertyMap.get(ruleTypeKey)
         } else {
             return []
         }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/util/GroovyUtil.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/util/GroovyUtil.groovy
@@ -19,9 +19,9 @@ class GroovyUtil {
         rootProject.dependencies {
             "${GROOVY_DEPS_CONFIG}" "org.codehaus.groovy:groovy:${groovyVersion}"
         }
-        new DependencyCache("groovy",
+        new DependencyCache("groovy" as String,
                 rootProject,
-                "${GROOVY_HOME_LOCATION}/lib",
+                "${GROOVY_HOME_LOCATION}/lib" as String,
                 [groovyConfig] as Set,
                 null)
 

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/util/GroovyUtil.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/util/GroovyUtil.groovy
@@ -19,7 +19,7 @@ class GroovyUtil {
         rootProject.dependencies {
             "${GROOVY_DEPS_CONFIG}" "org.codehaus.groovy:groovy:${groovyVersion}"
         }
-        new DependencyCache("groovy" as String,
+        new DependencyCache("groovy",
                 rootProject,
                 "${GROOVY_HOME_LOCATION}/lib" as String,
                 [groovyConfig] as Set,

--- a/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
@@ -208,11 +208,11 @@ final class BuckFileGenerator {
     }
 
     private static List<BuckRule> createRules(AndroidAppTarget target) {
-        List<BuckRule> rules = []
+        List<BuckRule> rules = [] as List<BuckRule>
         List<String> deps = [":${AndroidBuckRuleComposer.src(target)}"]
 
         Set<BuckRule> libRules = createRules((AndroidLibTarget) target,
-                target.exopackage ? target.exopackage.appClass : null)
+                target.exopackage ? target.exopackage.appClass : null) as Set<BuckRule>
         rules.addAll(libRules)
 
         libRules.each { BuckRule rule ->


### PR DESCRIPTION
Groovy mutates the underlying map with the default value when a default value is passed in Map.get . It doesn’t handle concurrent modification leading to multiple entries of the same key.