### PR TITLE
Reduce the number of manifest merger invocations

### DIFF
--- a/app/src/demo/AndroidManifest.xml
+++ b/app/src/demo/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.uber.okbuck.example">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:name="com.uber.okbuck.example.AppShell"

--- a/app/src/dev/AndroidManifest.xml
+++ b/app/src/dev/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.uber.okbuck.example">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:name="com.uber.okbuck.example.AppShell"

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidLibTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidLibTarget.groovy
@@ -2,6 +2,7 @@ package com.uber.okbuck.core.model.android
 
 import com.android.build.gradle.api.BaseVariant
 import com.android.manifmerger.ManifestMerger2
+import groovy.util.slurpersupport.GPathResult
 import org.gradle.api.Project
 
 /**
@@ -21,5 +22,10 @@ class AndroidLibTarget extends AndroidTarget {
     @Override
     ManifestMerger2.MergeType getMergeType() {
         return ManifestMerger2.MergeType.LIBRARY
+    }
+
+    @Override
+    String processManifestXml(GPathResult manifestXml) {
+        return null
     }
 }


### PR DESCRIPTION
- Do not require a pass of the manifest merger unless there are more than one manifest involved per variant
- Libraries do not need to process the manifest to set attributes like version code etc.