### PR TITLE
Add ability to add lint libraries to genrules

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
@@ -46,6 +46,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
     public static final String DEFAULT_CACHE_PATH = ".okbuck/cache"
     public static final String GROUP = "okbuck"
     public static final String BUCK_LINT = "buckLint"
+    public static final String BUCK_LINT_LIBRARY = "buckLintLibrary"
     public static final String LINT = "lint"
     public static final String TRANSFORM = "transform"
     public static final String RETROLAMBDA = "retrolambda"
@@ -197,6 +198,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
     private static void configureBuckProjects(Set<Project> buckProjects, Task setupOkbuck) {
         buckProjects.each { Project buckProject ->
             buckProject.configurations.maybeCreate(BUCK_LINT)
+            buckProject.configurations.maybeCreate(BUCK_LINT_LIBRARY)
             Task okbuckProjectTask = buckProject.tasks.maybeCreate(OKBUCK)
             okbuckProjectTask.doLast {
                 BuckFileGenerator.generate(buckProject)

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/LintRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/LintRuleComposer.groovy
@@ -56,6 +56,14 @@ final class LintRuleComposer extends JvmBuckRuleComposer {
 
         if (!target.main.sources.empty) {
             lintCmds.add("--classpath ${toLocation(":${src(target)}")}")
+
+            Set<String> lintLibraries = []
+            lintLibraries = lintLibraries + target.lintLibraries.externalDeps
+            lintLibraries = lintLibraries + target.lintLibraries.targetDeps
+            if (!lintLibraries.isEmpty()) {
+                String libraries = lintLibraries.join(':')
+                lintCmds.add("--libraries ${libraries}")
+            }
         }
         if (target.lintOptions.abortOnError) {
             lintCmds.add("--exitcode")

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/base/BuckRuleComposer.java
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/base/BuckRuleComposer.java
@@ -50,4 +50,8 @@ public abstract class BuckRuleComposer {
     public static String toLocation(final String target) {
         return "$(location " + target + ")";
     }
+
+    public static String toClasspath(final String target) {
+        return "$(classpath " + target + ")";
+    }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/java/AptRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/java/AptRuleComposer.groovy
@@ -1,7 +1,7 @@
 package com.uber.okbuck.composer.java
 
 import com.uber.okbuck.core.model.java.JavaTarget
-import com.uber.okbuck.rule.java.AptRule
+import com.uber.okbuck.rule.java.JavaLibraryWrapperRule
 
 final class AptRuleComposer extends JavaBuckRuleComposer {
 
@@ -9,11 +9,11 @@ final class AptRuleComposer extends JavaBuckRuleComposer {
         // no instance
     }
 
-    static AptRule compose(JavaTarget target) {
+    static JavaLibraryWrapperRule compose(JavaTarget target) {
         Set<String> aptDeps = external(target.apt.externalDeps.findAll { String dep ->
             dep.endsWith(".jar")
         })
         aptDeps += targets(target.apt.targetDeps)
-        return new AptRule(aptJar(target), aptDeps as List)
+        return new JavaLibraryWrapperRule(aptJar(target), aptDeps as List)
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/java/JavaTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/java/JavaTarget.groovy
@@ -45,7 +45,7 @@ abstract class JavaTarget extends JvmTarget {
     }
 
     /**
-     * Lint Scope
+     * Lint libraries Scope
      */
     Scope getLintLibraries() {
         File res = null

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/java/JavaTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/java/JavaTarget.groovy
@@ -5,6 +5,7 @@ import com.uber.okbuck.OkBuckGradlePlugin
 import com.uber.okbuck.core.model.base.Scope
 import com.uber.okbuck.core.model.jvm.JvmTarget
 import com.uber.okbuck.core.util.LintUtil
+import com.uber.okbuck.core.util.ProjectUtil
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 
@@ -41,6 +42,16 @@ abstract class JavaTarget extends JvmTarget {
         List<String> jvmArguments = []
         return new Scope(project, [OkBuckGradlePlugin.BUCK_LINT], sourceDirs, res, jvmArguments,
                 LintUtil.getLintDepsCache(project))
+    }
+
+    /**
+     * Lint Scope
+     */
+    Scope getLintLibraries() {
+        File res = null
+        Set<File> sourceDirs = []
+        List<String> jvmArguments = []
+        return new Scope(project, [OkBuckGradlePlugin.BUCK_LINT_LIBRARY], sourceDirs, res, jvmArguments, ProjectUtil.getDependencyCache(project))
     }
 
     LintOptions getLintOptions() {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
@@ -16,7 +16,6 @@ import com.uber.okbuck.composer.android.KeystoreRuleComposer
 import com.uber.okbuck.composer.android.LintRuleComposer
 import com.uber.okbuck.composer.android.PreBuiltNativeLibraryRuleComposer
 import com.uber.okbuck.composer.android.TrasformDependencyWriterRuleComposer
-import com.uber.okbuck.composer.base.BuckRuleComposer
 import com.uber.okbuck.composer.groovy.GroovyLibraryRuleComposer
 import com.uber.okbuck.composer.groovy.GroovyTestRuleComposer
 import com.uber.okbuck.composer.java.AptRuleComposer
@@ -44,7 +43,7 @@ import com.uber.okbuck.rule.android.ExopackageAndroidLibraryRule
 import com.uber.okbuck.rule.android.GenAidlRule
 import com.uber.okbuck.rule.base.BuckRule
 import com.uber.okbuck.rule.base.GenRule
-import com.uber.okbuck.rule.java.AptRule
+import com.uber.okbuck.rule.java.JavaLibraryWrapperRule
 import org.apache.commons.io.IOUtils
 import org.gradle.api.Project
 
@@ -161,7 +160,7 @@ final class BuckFileGenerator {
         // Apt
         List<String> aptDeps = []
         if (!target.annotationProcessors.empty && !target.apt.externalDeps.empty) {
-            AptRule aptRule = AptRuleComposer.compose(target)
+            JavaLibraryWrapperRule aptRule = AptRuleComposer.compose(target)
             rules.add(aptRule)
             aptDeps.add(":${aptRule.name}")
         }
@@ -198,7 +197,7 @@ final class BuckFileGenerator {
         OkBuckExtension okbuck = target.rootProject.okbuck
         LintExtension lint = okbuck.lint
         if (!lint.disabled) {
-            androidLibRules.add(LintRuleComposer.compose(target))
+            androidLibRules.addAll(LintRuleComposer.compose(target))
         }
 
         rules.addAll(androidLibRules)

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/android/AndroidLibraryWrapperRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/android/AndroidLibraryWrapperRule.groovy
@@ -1,0 +1,14 @@
+package com.uber.okbuck.rule.android
+
+import com.uber.okbuck.core.model.base.RuleType
+import com.uber.okbuck.rule.base.BuckRule
+
+final class AndroidLibraryWrapperRule extends BuckRule {
+
+    AndroidLibraryWrapperRule(String name, List<String> deps) {
+        super(RuleType.ANDROID_LIBRARY, name, [], deps)
+    }
+
+    @Override
+    protected void printContent(PrintStream printStream) {}
+}

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/java/JavaLibraryWrapperRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/java/JavaLibraryWrapperRule.groovy
@@ -3,10 +3,10 @@ package com.uber.okbuck.rule.java
 import com.uber.okbuck.core.model.base.RuleType
 import com.uber.okbuck.rule.base.BuckRule
 
-final class AptRule extends BuckRule {
+final class JavaLibraryWrapperRule extends BuckRule {
 
-    AptRule(String name, List<String> annotationProcessorDeps) {
-        super(RuleType.JAVA_LIBRARY, name, [], annotationProcessorDeps)
+    JavaLibraryWrapperRule(String name, List<String> deps) {
+        super(RuleType.JAVA_LIBRARY, name, [], deps)
     }
 
     @Override

--- a/libraries/emptylibrary/build.gradle
+++ b/libraries/emptylibrary/build.gradle
@@ -9,6 +9,7 @@ android {
 
 dependencies {
     compile deps.support.appCompat
+    buckLintLibrary deps.support.appCompat
 
     testCompile deps.test.junit
     testCompile project(':libraries:robolectric-base')


### PR DESCRIPTION
This is useful when using newer PSI based lints which can enhance the AST with proper type information when used with the `--libraries` flag.

To make the classes of any external or project dependency available to the buck linter for analysis, they can be specified as

```
dependencies {
  buckLintLibray "com.example:dep:1.0.0"
  buckLintLibray project(":dep")
}
```