### PR TITLE
Test case for lint PSI checks not running with Buck

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -44,7 +44,7 @@ def external = [
 
 def lint = [
         lint      : "com.android.tools.lint:lint:25.1.0",
-        lintApi   : "com.android.tools.lint:lint-api:25.1.0",
+        lintApi   : "com.android.tools.lint:lint-api:25.2.2",
         lintChecks: "com.android.tools.lint:lint-checks:25.1.0",
         lintTests : "com.android.tools.lint:lint-tests:25.1.0",
 ]

--- a/libraries/customLintLibrary/build.gradle
+++ b/libraries/customLintLibrary/build.gradle
@@ -27,7 +27,7 @@ jar {
 
 defaultTasks 'assemble'
 
-task lint(type: Copy, dependsOn: build) {
+task install(type: Copy, dependsOn: build) {
     from configurations.lintChecks
     into System.getProperty('user.home') + '/.android/lint/'
 }

--- a/libraries/customLintLibrary/build.gradle
+++ b/libraries/customLintLibrary/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'application'
 
 repositories {
     mavenCentral()
@@ -26,11 +27,6 @@ jar {
 }
 
 defaultTasks 'assemble'
-
-task install(type: Copy, dependsOn: build) {
-    from configurations.lintChecks
-    into System.getProperty('user.home') + '/.android/lint/'
-}
 
 configurations.all {
     exclude group: "org.bouncycastle"

--- a/libraries/customLintLibrary/build.gradle
+++ b/libraries/customLintLibrary/build.gradle
@@ -1,23 +1,35 @@
 apply plugin: 'java'
-apply plugin: 'application'
 
 repositories {
     mavenCentral()
 }
 
+configurations {
+    lintChecks
+}
+
 dependencies {
     compile deps.lint.lintApi
-    compile deps.lint.lintChecks
+    lintChecks files(jar)
 
     testCompile deps.lint.lint
     testCompile deps.lint.lintTests
 }
 
 jar {
+    baseName 'com.uber.lint'
+    version '1.0'
     manifest {
         attributes 'Lint-Registry': 'com.uber.lint.LintRegistry'
     }
     exclude 'META-INF'
+}
+
+defaultTasks 'assemble'
+
+task lint(type: Copy, dependsOn: build) {
+    from configurations.lintChecks
+    into System.getProperty('user.home') + '/.android/lint/'
 }
 
 configurations.all {

--- a/libraries/customLintLibrary/src/main/java/com/uber/lint/SystemCurrentTimeMillisDetector.java
+++ b/libraries/customLintLibrary/src/main/java/com/uber/lint/SystemCurrentTimeMillisDetector.java
@@ -1,62 +1,44 @@
 package com.uber.lint;
 
-import com.android.annotations.NonNull;
-import com.android.annotations.Nullable;
 import com.android.tools.lint.detector.api.Category;
 import com.android.tools.lint.detector.api.Detector;
+import com.android.tools.lint.detector.api.Detector.JavaPsiScanner;
 import com.android.tools.lint.detector.api.Implementation;
 import com.android.tools.lint.detector.api.Issue;
 import com.android.tools.lint.detector.api.JavaContext;
 import com.android.tools.lint.detector.api.Scope;
 import com.android.tools.lint.detector.api.Severity;
+import com.intellij.psi.JavaElementVisitor;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiMethodCallExpression;
 
 import java.util.Collections;
 import java.util.List;
 
-import lombok.ast.AstVisitor;
-import lombok.ast.MethodInvocation;
-
-/**
- * Custom Lint Check to prevent useage of System.currentTimeMillis.
- */
-public class SystemCurrentTimeMillisDetector extends Detector implements Detector.JavaScanner {
-
+public class SystemCurrentTimeMillisDetector extends Detector implements JavaPsiScanner {
     public static final String CHECK_METHOD_TO_EXCLUDE = "currentTimeMillis";
     public static final String CHECK_PACKAGE_TO_EXCLUDE = "java.lang.System";
 
     public static final String ISSUE_ID = "DontUseSystemTime";
     public static final Issue ISSUE = Issue.create(
-            ISSUE_ID,
-            "Don't use System.currentTimeMillis()",
-            "This method is blocked from useage. This can't be easily mocked, injected, or tested.",
-            Category.CORRECTNESS,
-            6,
-            Severity.ERROR,
-            new Implementation(SystemCurrentTimeMillisDetector.class, Scope.JAVA_FILE_SCOPE)
+        ISSUE_ID,
+        "Don't use System.currentTimeMillis()",
+        "This method is blocked from useage. This can't be easily mocked, injected, or tested.",
+        Category.CORRECTNESS,
+        6,
+        Severity.ERROR,
+        new Implementation(SystemCurrentTimeMillisDetector.class, Scope.JAVA_FILE_SCOPE)
     );
 
-    /**
-     * Determine the method names we are interested in for this check.
-     *
-     * @return a list representing the method names to check
-     */
-    @Nullable
     @Override
     public List<String> getApplicableMethodNames() {
         return Collections.singletonList(CHECK_METHOD_TO_EXCLUDE);
     }
 
-    /**
-     * Check that the currentTimeMillis() came from the System package, if so raise an error.
-     *
-     * @param context
-     * @param visitor
-     * @param node
-     */
     @Override
-    public void visitMethod(@NonNull JavaContext context, @Nullable AstVisitor visitor,
-                            @NonNull MethodInvocation node) {
+    public void visitMethod(JavaContext context, JavaElementVisitor visitor,
+        PsiMethodCallExpression call, PsiMethod method) {
         String message = "System.currentTimeMillis() should not be used as this can't be easily mocked and tested.";
-        context.report(ISSUE, node, context.getLocation(node.astName()), message);
+        context.report(ISSUE, call, context.getLocation(call), message);
     }
 }

--- a/libraries/lintErrorLibrary/build.gradle
+++ b/libraries/lintErrorLibrary/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'me.tatarka.retrolambda'
 
 dependencies {
     buckLint project (':libraries:customLintLibrary')
+    compile project (':libraries:customLintLibrary')
     compile deps.support.appCompat
 
     testCompile deps.test.junit

--- a/libraries/lintErrorLibrary/build.gradle
+++ b/libraries/lintErrorLibrary/build.gradle
@@ -1,9 +1,13 @@
 apply plugin: 'com.android.library'
 apply plugin: 'me.tatarka.retrolambda'
 
+configurations {
+    lintChecks
+}
+
 dependencies {
     buckLint project (':libraries:customLintLibrary')
-    compile project (':libraries:customLintLibrary')
+    lintChecks project (':libraries:customLintLibrary')
     compile deps.support.appCompat
 
     testCompile deps.test.junit


### PR DESCRIPTION
This PR is a test case for demonstrating that Buck doesn't seem to correctly run PSI based lint checks.

How to verify:

```
./gradlew libraries:lintErrorLibrary:lint # 1 error found
./buckw build //libraries/lintErrorLibrary:lint_release # no errors found
```