### PR TITLE
Only resolve subset of useful configurations during okbuck

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/Scope.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/Scope.groovy
@@ -69,7 +69,7 @@ class Scope {
     }
 
     private void extractConfigurations(Collection<String> configurations) {
-        List<Configuration> validConfigurations = []
+        Set<Configuration> validConfigurations = []
         configurations.each { String configName ->
             try {
                 Configuration configuration = project.configurations.getByName(configName)
@@ -77,6 +77,7 @@ class Scope {
             } catch (UnknownConfigurationException ignored) {
             }
         }
+        validConfigurations = useful(validConfigurations)
 
         // get all first level external dependencies
         validConfigurations.collect {
@@ -141,6 +142,12 @@ class Scope {
                         "inside ${project.rootProject.projectDir}")
             }
             external.add(ExternalDependency.fromLocal(localDep))
+        }
+    }
+
+    static Set<Configuration> useful(Set<Configuration> configurations) {
+        return configurations.findAll { Configuration configuration ->
+            !configuration.dependencies.empty || !configurations.containsAll(configuration.extendsFrom)
         }
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/java/JavaTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/java/JavaTarget.groovy
@@ -72,11 +72,13 @@ abstract class JavaTarget extends JvmTarget {
         Set<Configuration> configurations = new HashSet()
         depConfigNames.each { String configName ->
             try {
-                configurations.add(project.configurations.getByName(configName))
+                Configuration configuration = project.configurations.getByName(configName)
+                if (configuration.dependencies)
+                    configurations.add(project.configurations.getByName(configName))
             } catch (UnknownConfigurationException ignored) {
             }
         }
-        return configurations
+        return Scope.useful(configurations)
     }
 
     /**


### PR DESCRIPTION
- Fixes #362 
- The android gradle plugin creates many configurations for every buildType and flavor combination. Even standard configurations may not always be used by projects i.e they may only declare dependencies on a few configurations per project. This change filters out configurations that are useful for building and ignores resolving all possible configurations to speedup okbuck time.