### PR TITLE
Don't ignore the .okbuck folder in watchman

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -3,7 +3,6 @@
         "buck-out",
         ".buckd",
         ".idea",
-        ".okbuck",
         "build",
         ".gradle",
         ".swp",

--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/wrapper/WATCHMAN_CONFIG
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/wrapper/WATCHMAN_CONFIG
@@ -3,7 +3,6 @@
         "buck-out",
         ".buckd",
         ".idea",
-        ".okbuck",
         "build",
         ".gradle",
         ".swp",


### PR DESCRIPTION
If your buckconfig is set to use watchman as the glob_handler like the following:
```
[project]
    glob_handler = watchman
```

then having watchman ignore the `.okbuck` folder causes issues. There are a number of generated build rules within `.okbuck` like those within `cache/BUCK`, `cache/lint/BUCK` and `keystore/app/BUCK` which rely on globs to find files. If watchman ignores the `.okbuck` dir, those watchman queries blow up and the build fails.


The downside of this is that there may be some false positives but hopefully in the future we can more specific ignore or include specific directories for watchman.

cc @kageiit 