### PR TITLE
Add ability to translate test environment

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidTestRuleComposer.groovy
@@ -51,7 +51,7 @@ final class AndroidTestRuleComposer extends AndroidBuckRuleComposer {
                 target.targetCompatibility,
                 target.postprocessClassesCommands,
                 target.test.jvmArgs,
-                target.testRunnerJvmArgs,
+                target.testOptions,
                 target.test.resourcesDir,
                 RobolectricUtil.ROBOLECTRIC_CACHE,
                 target.getExtraOpts(RuleType.ROBOLECTRIC_TEST))

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/groovy/GroovyTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/groovy/GroovyTestRuleComposer.groovy
@@ -39,7 +39,7 @@ final class GroovyTestRuleComposer extends JvmBuckRuleComposer {
                 target.sourceCompatibility,
                 target.targetCompatibility,
                 target.test.jvmArgs,
-                target.testRunnerJvmArgs,
+                target.testOptions,
                 target.getExtraOpts(RuleType.GROOVY_TEST))
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/java/JavaTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/java/JavaTestRuleComposer.groovy
@@ -44,7 +44,7 @@ final class JavaTestRuleComposer extends JvmBuckRuleComposer {
                 target.targetCompatibility,
                 target.postprocessClassesCommands,
                 target.test.jvmArgs,
-                target.testRunnerJvmArgs,
+                target.testOptions,
                 target.getExtraOpts(RuleType.JAVA_TEST))
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/kotlin/KotlinTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/kotlin/KotlinTestRuleComposer.groovy
@@ -36,7 +36,7 @@ final class KotlinTestRuleComposer extends JvmBuckRuleComposer {
                 target.targetCompatibility,
                 Collections.emptyList(),
                 target.test.jvmArgs,
-                target.testRunnerJvmArgs,
+                target.testOptions,
                 target.getExtraOpts(RuleType.KOTLIN_TEST))
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidTarget.groovy
@@ -13,6 +13,7 @@ import com.android.manifmerger.MergingReport
 import com.android.utils.ILogger
 import com.uber.okbuck.core.model.base.Scope
 import com.uber.okbuck.core.model.java.JavaLibTarget
+import com.uber.okbuck.core.model.jvm.TestOptions
 import com.uber.okbuck.core.util.FileUtil
 import groovy.util.slurpersupport.GPathResult
 import groovy.xml.StreamingMarkupBuilder
@@ -141,11 +142,14 @@ abstract class AndroidTarget extends JavaLibTarget {
     }
 
     @Override
-    List<String> getTestRunnerJvmArgs() {
+    TestOptions getTestOptions() {
         Test testTask = project.tasks.withType(Test).find {
             it.name == "${VariantType.UNIT_TEST.prefix}${name.capitalize()}${VariantType.UNIT_TEST.suffix}" as String
         }
-        return testTask != null ? testTask.allJvmArgs : []
+        List<String> jvmArgs = testTask != null ? testTask.getAllJvmArgs() : Collections.<String>emptyList()
+        Map<String, Object> env = testTask != null ? testTask.getEnvironment() : Collections.emptyMap()
+        env.keySet().removeAll(System.getenv().keySet())
+        return new TestOptions(jvmArgs, env)
     }
 
     List<String> getBuildConfigFields() {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/jvm/JvmTarget.java
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/jvm/JvmTarget.java
@@ -8,6 +8,7 @@ import org.gradle.api.tasks.testing.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public abstract class JvmTarget extends Target {
 
@@ -28,14 +29,17 @@ public abstract class JvmTarget extends Target {
     public abstract Scope getTest();
 
     /**
-     * List of test jvm args
+     * The test options
      */
-    public List<String> getTestRunnerJvmArgs() {
+    public TestOptions getTestOptions() {
         try {
             Test testTask = getProject().getTasks().withType(Test.class).getByName("test");
-            return testTask != null ? testTask.getAllJvmArgs() : Collections.<String>emptyList();
+            List<String> jvmArgs = testTask != null ? testTask.getAllJvmArgs() : Collections.<String>emptyList();
+            Map<String, Object> env = testTask != null ? testTask.getEnvironment() : Collections.emptyMap();
+            env.keySet().removeAll(System.getenv().keySet());
+            return new TestOptions(jvmArgs, env);
         } catch (Exception e) {
-            return Collections.emptyList();
+            return TestOptions.EMPTY;
         }
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/jvm/TestOptions.java
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/jvm/TestOptions.java
@@ -1,0 +1,26 @@
+package com.uber.okbuck.core.model.jvm;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public final class TestOptions {
+
+    private final List<String> jvmArgs;
+    private final Map<String, Object> env;
+
+    public static TestOptions EMPTY = new TestOptions(Collections.emptyList(), Collections.emptyMap());
+
+    public TestOptions(List<String> jvmArgs, Map<String, Object> env) {
+        this.jvmArgs = jvmArgs;
+        this.env = env;
+    }
+
+    public List<String> getJvmArgs() {
+        return jvmArgs;
+    }
+
+    public Map<String, Object> getEnv() {
+        return env;
+    }
+}

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/android/AndroidLibraryRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/android/AndroidLibraryRule.groovy
@@ -1,6 +1,7 @@
 package com.uber.okbuck.rule.android
 
 import com.uber.okbuck.core.model.base.RuleType
+import com.uber.okbuck.core.model.jvm.TestOptions
 
 final class AndroidLibraryRule extends AndroidRule {
 
@@ -44,7 +45,7 @@ final class AndroidLibraryRule extends AndroidRule {
                 targetCompatibility,
                 postprocessClassesCommands,
                 options,
-                null,
+                TestOptions.EMPTY,
                 generateR2,
                 null,
                 null,

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/android/AndroidRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/android/AndroidRule.groovy
@@ -1,6 +1,7 @@
 package com.uber.okbuck.rule.android
 
 import com.uber.okbuck.core.model.base.RuleType
+import com.uber.okbuck.core.model.jvm.TestOptions
 import com.uber.okbuck.rule.base.BuckRule
 import org.apache.commons.lang.StringUtils
 
@@ -17,7 +18,7 @@ abstract class AndroidRule extends BuckRule {
     private final String mTargetCompatibility
     private final List<String> mPostprocessClassesCommands
     private final List<String> mOptions
-    private final List<String> mTestRunnerJvmArgs
+    private final TestOptions mTestOptions
     private final Set<String> mProvidedDeps
     private final boolean mGenerateR2
     private final String mResourcesDir
@@ -46,7 +47,7 @@ abstract class AndroidRule extends BuckRule {
             String targetCompatibility,
             List<String> postprocessClassesCommands,
             List<String> options,
-            List<String> testRunnerJvmArgs,
+            TestOptions testOptions,
             boolean generateR2,
             String resourcesDir,
             String runtimeDependency,
@@ -66,7 +67,7 @@ abstract class AndroidRule extends BuckRule {
         mTargetCompatibility = targetCompatibility
         mPostprocessClassesCommands = postprocessClassesCommands
         mOptions = options
-        mTestRunnerJvmArgs = testRunnerJvmArgs
+        mTestOptions = testOptions
         mProvidedDeps = providedDeps
         mGenerateR2 = generateR2
         mResourcesDir = resourcesDir
@@ -181,12 +182,20 @@ abstract class AndroidRule extends BuckRule {
             printer.println("\t],")
         }
 
-        if (mTestRunnerJvmArgs) {
+        if (mTestOptions.jvmArgs) {
             printer.println("\tvm_args = [")
-            mTestRunnerJvmArgs.each { String arg ->
+            mTestOptions.jvmArgs.each { String arg ->
                 printer.println("\t\t'${arg}',")
             }
             printer.println("\t],")
+        }
+
+        if (mTestOptions.env) {
+            printer.println("\tenv = {")
+            mTestOptions.env.each { String key, Object value ->
+                printer.println("\t\t'${key}': '${value.toString()}',")
+            }
+            printer.println("\t},")
         }
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/android/AndroidTestRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/android/AndroidTestRule.groovy
@@ -1,6 +1,7 @@
 package com.uber.okbuck.rule.android
 
 import com.uber.okbuck.core.model.base.RuleType
+import com.uber.okbuck.core.model.jvm.TestOptions
 
 final class AndroidTestRule extends AndroidRule {
 
@@ -21,7 +22,7 @@ final class AndroidTestRule extends AndroidRule {
             String targetCompatibility,
             List<String> postprocessClassesCommands,
             List<String> options,
-            List<String> testRunnerJvmArgs,
+            TestOptions testOptions,
             String mResourcesDir,
             String runtimeDependency,
             Set<String> extraOpts) {
@@ -43,7 +44,7 @@ final class AndroidTestRule extends AndroidRule {
                 targetCompatibility,
                 postprocessClassesCommands,
                 options,
-                testRunnerJvmArgs,
+                testOptions,
                 false,
                 mResourcesDir,
                 runtimeDependency,

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/groovy/GroovyLibraryRule.java
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/groovy/GroovyLibraryRule.java
@@ -1,6 +1,7 @@
 package com.uber.okbuck.rule.groovy;
 
 import com.uber.okbuck.core.model.base.RuleType;
+import com.uber.okbuck.core.model.jvm.TestOptions;
 
 import java.util.Collections;
 import java.util.List;
@@ -33,7 +34,7 @@ public final class GroovyLibraryRule extends GroovyRule {
                 sourceCompatibility,
                 targetCompatibility,
                 javacOptions,
-                Collections.emptyList(),
+                TestOptions.EMPTY,
                 Collections.emptyList(),
                 extraOpts);
     }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/groovy/GroovyRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/groovy/GroovyRule.groovy
@@ -1,6 +1,7 @@
 package com.uber.okbuck.rule.groovy
 
 import com.uber.okbuck.core.model.base.RuleType
+import com.uber.okbuck.core.model.jvm.TestOptions
 import com.uber.okbuck.rule.base.BuckRule
 import org.apache.commons.lang.StringUtils
 
@@ -13,7 +14,7 @@ abstract class GroovyRule extends BuckRule {
     private final String mSourceCompatibility
     private final String mTargetCompatibility
     private final List<String> mJavacOptions
-    private final List<String> mTestRunnerJvmArgs
+    private final TestOptions mTestOptions
     private final Set<String> mProvidedDeps
     private final List<String> mLabels
 
@@ -30,7 +31,7 @@ abstract class GroovyRule extends BuckRule {
             String sourceCompatibility,
             String targetCompatibility,
             List<String> javacOptions,
-            List<String> testRunnerJvmArgs,
+            TestOptions testOptions,
             List<String> labels,
             Set<String> extraOpts) {
 
@@ -42,7 +43,7 @@ abstract class GroovyRule extends BuckRule {
         mTargetCompatibility = targetCompatibility
         mResourcesDir = resourcesDir
         mJavacOptions = javacOptions
-        mTestRunnerJvmArgs = testRunnerJvmArgs
+        mTestOptions = testOptions
         mProvidedDeps = providedDeps
         mLabels = labels
     }
@@ -107,12 +108,20 @@ abstract class GroovyRule extends BuckRule {
             printer.println("\t],")
         }
 
-        if (mTestRunnerJvmArgs) {
+        if (mTestOptions.jvmArgs) {
             printer.println("\tvm_args = [")
-            mTestRunnerJvmArgs.each { String arg ->
+            mTestOptions.jvmArgs.each { String arg ->
                 printer.println("\t\t'${arg}',")
             }
             printer.println("\t],")
+        }
+
+        if (mTestOptions.env) {
+            printer.println("\tenv = {")
+            mTestOptions.env.each { String key, Object value ->
+                printer.println("\t\t'${key}': '${value.toString()}',")
+            }
+            printer.println("\t},")
         }
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/groovy/GroovyTestRule.java
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/groovy/GroovyTestRule.java
@@ -1,6 +1,7 @@
 package com.uber.okbuck.rule.groovy;
 
 import com.uber.okbuck.core.model.base.RuleType;
+import com.uber.okbuck.core.model.jvm.TestOptions;
 
 import java.util.Arrays;
 import java.util.List;
@@ -22,7 +23,7 @@ public final class GroovyTestRule extends GroovyRule {
             String sourceCompatibility,
             String targetCompatibility,
             List<String> javacOptions,
-            List<String> testRunnerJvmArgs,
+            TestOptions testOptions,
             Set<String> extraOpts) {
         super(RuleType.GROOVY_TEST,
                 name,
@@ -36,7 +37,7 @@ public final class GroovyTestRule extends GroovyRule {
                 sourceCompatibility,
                 targetCompatibility,
                 javacOptions,
-                testRunnerJvmArgs,
+                testOptions,
                 GROOVY_TEST_LABELS,
                 extraOpts);
     }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/java/JavaLibraryRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/java/JavaLibraryRule.groovy
@@ -1,6 +1,7 @@
 package com.uber.okbuck.rule.java
 
 import com.uber.okbuck.core.model.base.RuleType
+import com.uber.okbuck.core.model.jvm.TestOptions
 
 class JavaLibraryRule extends JavaRule {
 
@@ -35,7 +36,7 @@ class JavaLibraryRule extends JavaRule {
                 targetCompatibility,
                 postprocessClassesCommands,
                 options,
-                null,
+                TestOptions.EMPTY,
                 testTargets,
                 null,
                 extraOpts)

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/java/JavaRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/java/JavaRule.groovy
@@ -1,6 +1,7 @@
 package com.uber.okbuck.rule.java
 
 import com.uber.okbuck.core.model.base.RuleType
+import com.uber.okbuck.core.model.jvm.TestOptions
 import com.uber.okbuck.rule.base.BuckRule
 
 abstract class JavaRule extends BuckRule {
@@ -13,7 +14,7 @@ abstract class JavaRule extends BuckRule {
     private final String mTargetCompatibility
     private final List<String> mPostprocessClassesCommands
     private final List<String> mOptions
-    private final List<String> mTestRunnerJvmArgs
+    private final TestOptions mTestOptions
     private final Set<String> mProvidedDeps
     private final List<String> mTestTargets
     private final List<String> mLabels
@@ -33,7 +34,7 @@ abstract class JavaRule extends BuckRule {
             String targetCompatibility,
             List<String> postprocessClassesCommands,
             List<String> options,
-            List<String> testRunnerJvmArgs,
+            TestOptions testOptions,
             List<String> testTargets,
             List<String> labels = null,
             Set<String> extraOpts = []) {
@@ -47,7 +48,7 @@ abstract class JavaRule extends BuckRule {
         mResourcesDir = resourcesDir
         mPostprocessClassesCommands = postprocessClassesCommands
         mOptions = options
-        mTestRunnerJvmArgs = testRunnerJvmArgs
+        mTestOptions = testOptions
         mProvidedDeps = providedDeps
         mTestTargets = testTargets
         mLabels = labels
@@ -131,12 +132,20 @@ abstract class JavaRule extends BuckRule {
             printer.println("\t],")
         }
 
-        if (mTestRunnerJvmArgs) {
+        if (mTestOptions.jvmArgs) {
             printer.println("\tvm_args = [")
-            mTestRunnerJvmArgs.each { String arg ->
+            mTestOptions.jvmArgs.each { String arg ->
                 printer.println("\t\t'${arg}',")
             }
             printer.println("\t],")
+        }
+
+        if (mTestOptions.env) {
+            printer.println("\tenv = {")
+            mTestOptions.env.each { String key, Object value ->
+                printer.println("\t\t'${key}': '${value.toString()}',")
+            }
+            printer.println("\t},")
         }
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/java/JavaTestRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/java/JavaTestRule.groovy
@@ -1,6 +1,7 @@
 package com.uber.okbuck.rule.java
 
 import com.uber.okbuck.core.model.base.RuleType
+import com.uber.okbuck.core.model.jvm.TestOptions
 
 class JavaTestRule extends JavaRule {
 
@@ -19,7 +20,7 @@ class JavaTestRule extends JavaRule {
             String targetCompatibility,
             List<String> postprocessClassesCommands,
             List<String> options,
-            List<String> testRunnerJvmArgs,
+            TestOptions testOptions,
             Set<String> extraOpts,
             RuleType ruleType = RuleType.JAVA_TEST,
             List<String> testLabels = JAVA_TEST_LABELS) {
@@ -37,7 +38,7 @@ class JavaTestRule extends JavaRule {
                 targetCompatibility,
                 postprocessClassesCommands,
                 options,
-                testRunnerJvmArgs,
+                testOptions,
                 null,
                 testLabels,
                 extraOpts)

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/kotlin/KotlinTestRule.java
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/kotlin/KotlinTestRule.java
@@ -1,6 +1,7 @@
 package com.uber.okbuck.rule.kotlin;
 
 import com.uber.okbuck.core.model.base.RuleType;
+import com.uber.okbuck.core.model.jvm.TestOptions;
 import com.uber.okbuck.rule.java.JavaTestRule;
 
 import java.util.Arrays;
@@ -24,7 +25,8 @@ public final class KotlinTestRule extends JavaTestRule {
             String targetCompatibility,
             List<String> postprocessClassesCommands,
             List<String> options,
-            List<String> testRunnerJvmArgs, Set<String> extraOpts) {
+            TestOptions testOptions,
+            Set<String> extraOpts) {
         super(name,
                 visibility,
                 deps,
@@ -37,7 +39,7 @@ public final class KotlinTestRule extends JavaTestRule {
                 targetCompatibility,
                 postprocessClassesCommands,
                 options,
-                testRunnerJvmArgs,
+                testOptions,
                 extraOpts,
                 RuleType.KOTLIN_TEST,
                 KOTLIN_TEST_LABELS);

--- a/libraries/javalibrary/build.gradle
+++ b/libraries/javalibrary/build.gradle
@@ -10,3 +10,7 @@ dependencies {
 
     testCompile deps.test.junit
 }
+
+test {
+    environment "TEST_ENV", "true"
+}


### PR DESCRIPTION
This allows buck test rules to consume the test environment variables set by the various gradle test tasks