### PR TITLE
Add support for creating extra dependency caches

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
@@ -157,6 +157,13 @@ class OkBuckGradlePlugin implements Plugin<Project> {
                 if (test.robolectric) {
                     RobolectricUtil.download(project)
                 }
+
+                // Create extra dependency caches if needed
+                okbuckExt.extraDepCaches.each { String cacheName ->
+                    Configuration extraConfiguration = project.configurations.maybeCreate("${cacheName}DepCache")
+                    new DependencyCache(cacheName, project, "${DEFAULT_CACHE_PATH}/${cacheName}",
+                            Collections.singleton(extraConfiguration))
+                }
             }
 
             // Configure okbuck task

--- a/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
@@ -63,6 +63,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
     public static final String WRAPPER = "wrapper"
     public static final String BUCK_WRAPPER = "buckWrapper"
     public static final String DEFAULT_CACHE_PATH = ".okbuck/cache"
+    public static final String EXTRA_DEP_CACHE_PATH = ".okbuck/cache/extra"
     public static final String GROUP = "okbuck"
     public static final String BUCK_LINT = "buckLint"
     public static final String BUCK_LINT_LIBRARY = "buckLintLibrary"
@@ -161,7 +162,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
                 // Create extra dependency caches if needed
                 okbuckExt.extraDepCaches.each { String cacheName ->
                     Configuration extraConfiguration = project.configurations.maybeCreate("${cacheName}DepCache")
-                    new DependencyCache(cacheName, project, "${DEFAULT_CACHE_PATH}/${cacheName}",
+                    new DependencyCache(cacheName, project, "${EXTRA_DEP_CACHE_PATH}/${cacheName}",
                             Collections.singleton(extraConfiguration))
                 }
             }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
@@ -161,7 +161,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
 
                 // Create extra dependency caches if needed
                 okbuckExt.extraDepCaches.each { String cacheName ->
-                    Configuration extraConfiguration = project.configurations.maybeCreate("${cacheName}DepCache")
+                    Configuration extraConfiguration = project.configurations.maybeCreate("${cacheName}ExtraDepCache")
                     new DependencyCache(cacheName, project, "${EXTRA_DEP_CACHE_PATH}/${cacheName}",
                             Collections.singleton(extraConfiguration))
                 }

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
@@ -66,6 +66,13 @@ public class OkBuckExtension {
      */
     public boolean resourceUnion = true;
 
+    /**
+     * Additional dependency caches.
+     * Every entry will create a new configuration "entryDepCache"
+     * that can be used to fetch and cache dependencies.
+     */
+    public Set<String> extraDepCaches = new HashSet<>();
+
     public OkBuckExtension(Project project) {
         buckProjects = project.getSubprojects();
     }


### PR DESCRIPTION
Every extra cache requested will create a new configuration "<name>ExtraDepCache" that can be used to fetch and cache dependencies that can be used for tooling purposes etc. during buck