### PR TITLE
Only put valid projects in the state file for okbuckclean.

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
@@ -54,7 +54,7 @@ final class BuckFileGenerator {
     /**
      * generate {@code BUCKFile}
      */
-    static Map<Project, BUCKFile> generate(Project project) {
+    static void generate(Project project) {
         OkBuckExtension okbuck = project.rootProject.okbuck
 
         TestExtension test = okbuck.test

--- a/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckCleanTask.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckCleanTask.java
@@ -2,6 +2,8 @@ package com.uber.okbuck.core.task;
 
 import com.google.common.collect.Sets;
 import com.uber.okbuck.OkBuckGradlePlugin;
+import com.uber.okbuck.core.model.base.ProjectType;
+import com.uber.okbuck.core.util.ProjectUtil;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
@@ -48,6 +50,7 @@ public class OkBuckCleanTask extends DefaultTask {
         // Get current project relative paths
         Set<String> currentProjectPaths =
                 projects.stream()
+                        .filter(project -> ProjectUtil.getType(project) != ProjectType.UNKNOWN)
                         .map(project -> rootProjectPath
                                 .relativize(project.getProjectDir().toPath()).toString()
                         )

--- a/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckCleanTask.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckCleanTask.java
@@ -58,7 +58,7 @@ public class OkBuckCleanTask extends DefaultTask {
 
         // Delete stale project's BUCK file
         Sets.difference(lastProjectPaths, currentProjectPaths)
-                .stream()
+                .parallelStream()
                 .map(p -> rootProjectPath.resolve(p).resolve(OkBuckGradlePlugin.BUCK))
                 .forEach(OkBuckCleanTask::deleteQuietly);
 


### PR DESCRIPTION
Verified that state files doesn't contain the project entries for intermediate folders with build.gradle which has just some configurations.