### PR TITLE
Fix .okbuck folder generation

### DIFF
--- a/buckw
+++ b/buckw
@@ -4,7 +4,7 @@
 ##
 ##  Buck wrapper script to invoke okbuck when needed, before running buck
 ##
-##  Created by OkBuck Gradle Plugin on : Mon Mar 06 13:56:01 PST 2017
+##  Created by OkBuck Gradle Plugin on : Wed Mar 29 15:03:12 PDT 2017
 ##
 #########################################################################
 
@@ -55,7 +55,7 @@ DEFAULT_BUCK_INSTALL_DIR="$HOME/.gradle/caches/okbuck/buck"
 CUSTOM_BUCK_REPO=""
 CUSTOM_REMOTE_NAME="custom"
 OKBUCK_SUCCESS="$WORKING_DIR/build/okbuck.success"
-OKBUCK_DIR=".okbuck"
+OKBUCK_DIR="$WORKING_DIR/.okbuck"
 MAX_DISPLAY_CHANGES=10
 
 ensureWatch ( ) {
@@ -75,13 +75,16 @@ getChanges ( ) {
             ["suffix", "gradle"],
             ["name", ["gradle-wrapper.properties", "lint.xml"]],
             ["match", "**/src/**/AndroidManifest.xml", "wholename"]
+        ],
+        ["not",
+            ["dirname", ".okbuck"]
         ]
     ],
     "fields": ["name"]
 }]
 EOT`
     SOURCE_ROOTS=`watchman --output-encoding=json --no-pretty -j 2>&1 <<-EOT
-["query", ".", {
+["query", "$WORKING_DIR", {
     "since": "n:okbuck_source_roots",
     "expression": ["allof",
         ["type", "d"],
@@ -89,6 +92,9 @@ EOT`
             ["match", "**/src/**/java", "wholename"],
             ["match", "**/src/**/res", "wholename"],
             ["match", "**/src/**/resources", "wholename"]
+        ],
+        ["not",
+            ["dirname", ".okbuck"]
         ]
     ],
     "fields": ["new", "exists", "name"]

--- a/buckw
+++ b/buckw
@@ -4,7 +4,7 @@
 ##
 ##  Buck wrapper script to invoke okbuck when needed, before running buck
 ##
-##  Created by OkBuck Gradle Plugin on : Wed Mar 29 15:03:12 PDT 2017
+##  Created by OkBuck Gradle Plugin on : Wed Mar 29 16:37:26 PDT 2017
 ##
 #########################################################################
 
@@ -159,7 +159,7 @@ setupBuckBinary ( ) {
             if [[ -z "$REMOTE_EXISTS" ]]; then
                 git remote add $CUSTOM_REMOTE_NAME $CUSTOM_BUCK_REPO
             fi
-            cd $WORKING_DIR
+            cd -
         fi
 
         BUCK_BINARY="$BUCK_HOME/bin/buck"

--- a/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
@@ -114,6 +114,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
                 repo = wrapper.repo
                 watch = wrapper.watch
                 sourceRoots = wrapper.sourceRoots
+                ignoredDirs = wrapper.ignoredDirs
             })
             buckWrapper.setGroup(GROUP)
             buckWrapper.setDescription("Create buck wrapper")

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/KeystoreRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/KeystoreRuleComposer.groovy
@@ -15,7 +15,7 @@ final class KeystoreRuleComposer {
     static String compose(AndroidAppTarget target) {
         AndroidAppTarget.Keystore keystore = target.keystore
         if (keystore != null) {
-            File storeDir = target.project.rootProject.file(".okbuck/keystore/${target.identifier.replaceAll(':', '_')}")
+            File storeDir = target.rootProject.file(".okbuck/keystore/${target.identifier.replaceAll(':', '_')}")
             storeDir.mkdirs()
 
             File tmp = File.createTempFile("okbuck", "keystore")

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/KeystoreRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/KeystoreRuleComposer.groovy
@@ -15,7 +15,7 @@ final class KeystoreRuleComposer {
     static String compose(AndroidAppTarget target) {
         AndroidAppTarget.Keystore keystore = target.keystore
         if (keystore != null) {
-            File storeDir = new File(".okbuck/keystore/${target.identifier.replaceAll(':', '_')}")
+            File storeDir = target.project.rootProject.file(".okbuck/keystore/${target.identifier.replaceAll(':', '_')}")
             storeDir.mkdirs()
 
             File tmp = File.createTempFile("okbuck", "keystore")

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/LintUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/LintUtil.java
@@ -73,7 +73,7 @@ public final class LintUtil {
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     public static synchronized String getLintwConfigRule(Project project, File config) {
-        File configFile = new File(LINT_DEPS_CACHE + "/" + getLintwConfigName(project, config));
+        File configFile = project.getRootProject().file(LINT_DEPS_CACHE + "/" + getLintwConfigName(project, config));
         try {
             FileUtils.copyFile(config, configFile);
         } catch (IOException e) {

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/WrapperExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/WrapperExtension.java
@@ -38,4 +38,9 @@ public class WrapperExtension {
             "**/src/**/java",
             "**/src/**/res",
             "**/src/**/resources");
+
+    /**
+     * List of directories to ignore when querying for changes that should trigger okbuck runs
+     */
+    public Set<String> ignoredDirs = Sets.newHashSet(".okbuck");
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/wrapper/BuckWrapperTask.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/wrapper/BuckWrapperTask.java
@@ -60,12 +60,12 @@ public class BuckWrapperTask extends DefaultTask {
             return "";
         }
 
-        String ignore_exprs = ignoredDirs
+        String ignoreExprs = ignoredDirs
                 .parallelStream()
                 .map(ignoredDir -> "            [\"dirname\", \"" + ignoredDir + "\"]")
                 .collect(Collectors.joining(",\n"));
 
-        return "        [\"not\",\n" + ignore_exprs + "\n        ]";
+        return "        [\"not\",\n" + ignoreExprs + "\n        ]";
     }
 
     private static String toWatchmanMatchers(Set<String> wildcardPatterns) {
@@ -92,25 +92,25 @@ public class BuckWrapperTask extends DefaultTask {
             }
         }
 
-        String match_exprs = matches
+        String matchExprs = matches
                 .parallelStream()
                 .map(match -> "            [\"match\", \"" + match + "\", \"wholename\"]")
                 .collect(Collectors.joining(",\n"));
 
-        String suffix_exprs = suffixes
+        String suffixExprs = suffixes
                 .parallelStream()
                 .map(suffix -> "            [\"suffix\", \"" + suffix + "\"]")
                 .collect(Collectors.joining(",\n"));
 
-        String name_expr = names
+        String nameExpr = names
                 .parallelStream()
                 .map(name -> "\"" + name + "\"")
                 .collect(Collectors.joining(", "));
-        if (!name_expr.isEmpty()) {
-            name_expr = "            [\"name\", [" + name_expr + "]]";
+        if (!nameExpr.isEmpty()) {
+            nameExpr = "            [\"name\", [" + nameExpr + "]]";
         }
 
-        return Arrays.asList(suffix_exprs, name_expr, match_exprs)
+        return Arrays.asList(suffixExprs, nameExpr, matchExprs)
                 .parallelStream()
                 .filter(StringUtils::isNotEmpty)
                 .collect(Collectors.joining(",\n"));

--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/wrapper/BUCKW_TEMPLATE
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/wrapper/BUCKW_TEMPLATE
@@ -150,7 +150,7 @@ setupBuckBinary ( ) {
             if [[ -z "$REMOTE_EXISTS" ]]; then
                 git remote add $CUSTOM_REMOTE_NAME $CUSTOM_BUCK_REPO
             fi
-            cd $WORKING_DIR
+            cd -
         fi
 
         BUCK_BINARY="$BUCK_HOME/bin/buck"

--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/wrapper/BUCKW_TEMPLATE
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/wrapper/BUCKW_TEMPLATE
@@ -55,7 +55,7 @@ DEFAULT_BUCK_INSTALL_DIR="$HOME/.gradle/caches/okbuck/buck"
 CUSTOM_BUCK_REPO="${template-custom-buck-repo}"
 CUSTOM_REMOTE_NAME="custom"
 OKBUCK_SUCCESS="$WORKING_DIR/build/okbuck.success"
-OKBUCK_DIR=".okbuck"
+OKBUCK_DIR="$WORKING_DIR/.okbuck"
 MAX_DISPLAY_CHANGES=10
 
 ensureWatch ( ) {
@@ -72,19 +72,21 @@ getChanges ( ) {
         ["type", "f"],
         ["anyof",
 ${template-watch}
-        ]
+        ],
+${template-ignored-dirs}
     ],
     "fields": ["name"]
 }]
 EOT`
     SOURCE_ROOTS=`watchman --output-encoding=json --no-pretty -j 2>&1 <<-EOT
-["query", ".", {
+["query", "$WORKING_DIR", {
     "since": "n:okbuck_source_roots",
     "expression": ["allof",
         ["type", "d"],
         ["anyof",
 ${template-source-roots}
-        ]
+        ],
+${template-ignored-dirs}
     ],
     "fields": ["new", "exists", "name"]
 }]


### PR DESCRIPTION
This PR does a few things:

1) Some of the files/subdirectories of the `.okbuck` directory were being created relative to where `gradlew` was being invoked from, as opposed to the root project dir. This fixes that so that everything under the `.okbuck` directory is created in the right spot.

2) Updates buckw so that `.okbuck` is looked for at `$WORKING_DIR/.okbuck` so that the check for previous successful okbuck runs works appropriately

3) Adds support to buck wrapper generation to ignore specific directories. We were doing this internally and I thought it would be helpful to upstream. This will make sure the watchman queries correctly not attempt to track changes under the `.okbuck` directory.


Our `buckw` internally also looks a bit different because our watchman project root is a folder above our android directory. This can be generically supported by looking at the output of `watchman watch-project` to check the root it's watching and whether there is a relative root specified. Those values can be saved and used for the queries. E.g. if `watchman watch-project` gives something like the following:

```
{
    "version": "4.7.0",
    "watch": "/Users/sean_abraham/projects",
    "watcher": "fsevents"
}
```

We can structure the watchman queries like:
```
PROJECT_ROOT="/Users/sean_abraham/projects"
watchman --output-encoding=json --no-pretty -j 2>&1 <<-EOT
["query", "$PROJECT_ROOT", {
    "since": "n:okbuck_trig",
    ...
}]
EOT
```

And if `watchman watch-project` gives something like this:
```
{
    "version": "4.7.0",
    "watch": "/Users/sean_abraham/project",
    "watcher": "fsevents",
    "relative_path": "android"
}
```

We can structure the watchman queries like:
```
PROJECT_ROOT="/Users/sean_abraham/projects"
RELATIVE_ROOT="android"
watchman --output-encoding=json --no-pretty -j 2>&1 <<-EOT
["query", "$PROJECT_ROOT", {
    "since": "n:okbuck_trig",
    "relative_root": "$RELATIVE_ROOT",
    ...
}]
EOT
```

This shouldn't be too hard to do but pretty annoying in bash so I decided against doing it in this PR.


@kageiit 