### PR TITLE
Use sourceSets to get sources of JavaTarget

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/java/JavaLibTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/java/JavaLibTarget.groovy
@@ -18,7 +18,7 @@ class JavaLibTarget extends JavaTarget {
     Scope getMain() {
         return new Scope(project,
                 compileConfigs,
-                project.files("src/main/java") as Set,
+                project.sourceSets.main.java.srcDirs as Set,
                 project.file("src/main/resources"),
                 project.compileJava.options.compilerArgs as List)
     }
@@ -27,7 +27,7 @@ class JavaLibTarget extends JavaTarget {
     Scope getTest() {
         return new Scope(project,
                 expand(compileConfigs, TEST_PREFIX, true),
-                project.files("src/test/java") as Set,
+                project.sourceSets.test.java.srcDirs as Set,
                 project.file("src/test/resources"),
                 project.compileTestJava.options.compilerArgs as List)
     }


### PR DESCRIPTION
Verified no buck files changes with same build.gradle configuration.
On overriding test sources to be `[]` `java_test` rule is not generated.