### PR TITLE
Updated readme with the new android-ndk location

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ OkBuck is a gradle plugin that lets developers utilize the [Buck](https://buckbu
 brew update
 
 # Required to build and use buck
-brew install android-ndk ant
+brew install ant caskroom/cask/android-sdk
 
 # Optional, but recommended for faster development
 brew install watchman


### PR DESCRIPTION
Installing as currently stated in the `readme` results in:

```
Error: No available formula with the name "android-ndk"
It was migrated from homebrew/core to caskroom/cask/android-sdk.
```