### PR TITLE
Do not scan for sources for gradle api jars

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/Scope.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/Scope.groovy
@@ -15,10 +15,6 @@ import org.gradle.api.artifacts.UnknownConfigurationException
 
 @EqualsAndHashCode
 class Scope {
-
-    // These are used by conventions such as gradleApi() and localGroovy() and are whitelisted
-    private static final Set<String> WHITELIST_LOCAL_PATTERNS = ['generated-gradle-jars/gradle-api-', 'wrapper/dists']
-
     final String resourcesDir
     final Set<String> sources
     final Set<Target> targetDeps = [] as Set
@@ -136,7 +132,7 @@ class Scope {
             !resolvedFiles.contains(resolved)
         }.each { File localDep ->
             if (!FilenameUtils.directoryContains(project.rootProject.projectDir.absolutePath, localDep.absolutePath)
-                    && WHITELIST_LOCAL_PATTERNS.find { localDep.absolutePath.contains(it) } == null) {
+                    && !depCache.isWhiteListed(localDep)) {
                 throw new IllegalStateException("Local dependencies should be under project root. Dependencies " +
                         "outside the project can cause hard to reproduce builds. Please move dependency: ${localDep} " +
                         "inside ${project.rootProject.projectDir}")


### PR DESCRIPTION
- We do not have sources for these jars and they can take a long time to scan as their parent directory is the entire gradle cache directory
- Reduced the size of the super configuration by not adding project dependencies to it as we iterate all projects anyway
- Simplified source jar copy into dependency cache
- Verified generated buck files are exactly the same before and after