### PR TITLE
Support invoking okbuck from a different directory

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
@@ -92,6 +92,9 @@ class OkBuckGradlePlugin implements Plugin<Project> {
         RetrolambdaExtension retrolambda = okbuckExt.extensions.create(RETROLAMBDA, RetrolambdaExtension)
         okbuckExt.extensions.create(TRANSFORM, TransformExtension)
 
+        project.ext.buckRootDirectory = System.getProperty("okbuck.buckRoot") != null ?
+                            new File(System.getProperty("okbuck.buckRoot")) : project.getRootDir();
+
         // Create configurations
         project.configurations.maybeCreate(TransformUtil.CONFIGURATION_TRANSFORM)
         Configuration externalOkbuck = project.configurations.maybeCreate(CONFIGURATION_EXTERNAL)

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidBinaryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidBinaryRuleComposer.groovy
@@ -35,7 +35,7 @@ final class AndroidBinaryRuleComposer extends AndroidBuckRuleComposer {
         return new AndroidBinaryRule(bin(target), ["PUBLIC"], deps, manifestRuleName, keystoreRuleName,
                 target.multidexEnabled, target.linearAllocHardLimit, target.primaryDexPatterns,
                 target.exopackage != null, mappedCpuFilters, target.minifyEnabled,
-                fileRule(target.proguardConfig), target.placeholders, target.getExtraOpts(RuleType.ANDROID_BINARY),
+                fileRule(target.proguardConfig, target), target.placeholders, target.getExtraOpts(RuleType.ANDROID_BINARY),
                 target.includesVectorDrawables, transformRuleNames, bashCommand)
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidBuckRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidBuckRuleComposer.groovy
@@ -11,7 +11,7 @@ abstract class AndroidBuckRuleComposer extends JvmBuckRuleComposer {
     }
 
     static String resRule(AndroidTarget target) {
-        return "//${target.getPath()}:${res(target)}"
+        return "${rootPrefix(target)}${target.getPath()}:${res(target)}"
     }
 
     static String manifest(AndroidTarget target) {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidLibraryRuleComposer.groovy
@@ -19,20 +19,20 @@ final class AndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
             final List<String> aidlRuleNames,
             String appClass) {
         List<String> libraryDeps = new ArrayList<>(deps)
-        libraryDeps.addAll(external(target.main.externalDeps))
+        libraryDeps.addAll(external(target.main.externalDeps, target))
         libraryDeps.addAll(targets(target.main.targetDeps))
 
         List<String> libraryAptDeps = []
-        libraryAptDeps.addAll(externalApt(target.apt.externalDeps))
+        libraryAptDeps.addAll(externalApt(target.apt.externalDeps, target))
         libraryAptDeps.addAll(targetsApt(target.apt.targetDeps))
 
         Set<String> providedDeps = []
-        providedDeps.addAll(external(target.provided.externalDeps))
+        providedDeps.addAll(external(target.provided.externalDeps, target))
         providedDeps.addAll(targets(target.provided.targetDeps))
         providedDeps.removeAll(libraryDeps)
 
         if (target.retrolambda) {
-            providedDeps.add(RetrolambdaUtil.getRtStubJarRule())
+            providedDeps.add(RetrolambdaUtil.getRtStubJarRule(target))
         }
 
         libraryDeps.addAll(target.main.targetDeps.findAll { Target targetDep ->
@@ -51,7 +51,7 @@ final class AndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
                 ["PUBLIC"],
                 libraryDeps,
                 target.main.sources,
-                fileRule(target.manifest),
+                fileRule(target.manifest, target),
                 target.annotationProcessors as List,
                 libraryAptDeps,
                 providedDeps,

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidManifestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidManifestRuleComposer.groovy
@@ -16,12 +16,12 @@ final class AndroidManifestRuleComposer extends AndroidBuckRuleComposer {
         List<String> deps = []
         deps.addAll(external(manifestScope.externalDeps.findAll { String dep ->
             dep.endsWith("aar")
-        }))
+        }, target))
 
         deps.addAll(targets(manifestScope.targetDeps.findAll { Target targetDep ->
             targetDep instanceof AndroidLibTarget
         }))
 
-        return new AndroidManifestRule(manifest(target), ["PUBLIC"], deps, fileRule(target.manifest))
+        return new AndroidManifestRule(manifest(target), ["PUBLIC"], deps, fileRule(target.manifest, target))
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidResourceRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidResourceRuleComposer.groovy
@@ -15,7 +15,7 @@ final class AndroidResourceRuleComposer extends AndroidBuckRuleComposer {
         List<String> resDeps = []
         resDeps.addAll(external(target.main.externalDeps.findAll { String dep ->
             dep.endsWith(".aar")
-        }))
+        }, target))
 
         resDeps.addAll(target.main.targetDeps.findAll { Target targetDep ->
             targetDep instanceof AndroidTarget

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidTestRuleComposer.groovy
@@ -20,20 +20,20 @@ final class AndroidTestRuleComposer extends AndroidBuckRuleComposer {
 
         List<String> testDeps = new ArrayList<>(deps)
         testDeps.add(":${src(target)}")
-        testDeps.addAll(external(target.test.externalDeps))
+        testDeps.addAll(external(target.test.externalDeps, target))
         testDeps.addAll(targets(target.test.targetDeps))
 
         List<String> testAptDeps = []
-        testAptDeps.addAll(external(target.testApt.externalDeps))
+        testAptDeps.addAll(external(target.testApt.externalDeps, target))
         testAptDeps.addAll(targets(target.testApt.targetDeps))
 
         Set<String> providedDeps = []
-        providedDeps.addAll(external(target.testProvided.externalDeps))
+        providedDeps.addAll(external(target.testProvided.externalDeps, target))
         providedDeps.addAll(targets(target.testProvided.targetDeps))
         providedDeps.removeAll(testDeps)
 
         if (target.retrolambda) {
-            providedDeps.add(RetrolambdaUtil.getRtStubJarRule())
+            providedDeps.add(RetrolambdaUtil.getRtStubJarRule(target))
         }
 
         return new AndroidTestRule(
@@ -41,7 +41,7 @@ final class AndroidTestRuleComposer extends AndroidBuckRuleComposer {
                 ["PUBLIC"],
                 testDeps,
                 target.test.sources,
-                fileRule(target.manifest),
+                fileRule(target.manifest, target),
                 target.testAnnotationProcessors as List,
                 testAptDeps,
                 providedDeps,

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/ExopackageAndroidLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/ExopackageAndroidLibraryRuleComposer.groovy
@@ -12,7 +12,7 @@ final class ExopackageAndroidLibraryRuleComposer extends AndroidBuckRuleComposer
 
     static ExopackageAndroidLibraryRule compose(AndroidAppTarget target) {
         List<String> deps = []
-        deps.addAll(external(target.exopackage.externalDeps))
+        deps.addAll(external(target.exopackage.externalDeps, target))
         deps.addAll(targets(target.exopackage.targetDeps))
         deps.add(":${buildConfig(target)}")
 

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/GenAidlRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/GenAidlRuleComposer.groovy
@@ -13,7 +13,7 @@ final class GenAidlRuleComposer extends AndroidBuckRuleComposer {
         return new GenAidlRule(aidl(target, aidlDir),
                 aidlDir,
                 "${target.path}/${aidlDir}",
-                fileRule(target.manifest),
+                fileRule(target.manifest, target),
                 targets(target.main.targetDeps))
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/KeystoreRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/KeystoreRuleComposer.groovy
@@ -28,7 +28,7 @@ final class KeystoreRuleComposer extends BuckRuleComposer {
             writer.println("key.alias.password=${keystore.keyPassword}")
             writer.close()
 
-            return fileRule(FileUtil.getRelativePath(target.rootProject.projectDir, keyStoreGen))
+            return fileRule(FileUtil.getRelativePath(target.rootProject.projectDir, keyStoreGen), target)
         } else {
             throw new IllegalStateException("${target.name} of ${target.path} has no signing config set!")
         }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/base/BuckRuleComposer.java
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/base/BuckRuleComposer.java
@@ -2,9 +2,12 @@ package com.uber.okbuck.composer.base;
 
 import com.uber.okbuck.core.model.base.Target;
 import com.uber.okbuck.core.model.java.JavaLibTarget;
+import com.uber.okbuck.core.util.ProjectUtil;
 
 import org.apache.commons.io.FilenameUtils;
+import org.gradle.api.Project;
 
+import java.io.File;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -13,30 +16,30 @@ public abstract class BuckRuleComposer {
 
     private static final String SEPARATOR = ":";
 
-    public static Set<String> external(final Set<String> deps) {
+    public static Set<String> external(final Set<String> deps, final Target target) {
         return deps.parallelStream()
-                .map(BuckRuleComposer::fileRule)
+                .map(dep -> fileRule(dep, target))
                 .collect(Collectors.toSet());
     }
 
-    public static Set<String> externalApt(final Set<String> deps) {
-        return external(deps).parallelStream()
+    public static Set<String> externalApt(final Set<String> deps, final Target target) {
+        return external(deps, target).parallelStream()
                 .filter(dep -> dep.endsWith(".jar"))
                 .collect(Collectors.toSet());
     }
 
-    public static String fileRule(final String filePath) {
+    public static String fileRule(final String filePath, final Target target) {
         if (filePath == null) {
             return null;
         }
 
-        StringBuilder ext = new StringBuilder("//");
-        ext.append(filePath);
-        int ind = FilenameUtils.indexOfLastSeparator(filePath) + 2;
+        StringBuilder ext = new StringBuilder(filePath);
+        int ind = FilenameUtils.indexOfLastSeparator(filePath);
         if (ind >= 0) {
             ext = ext.replace(ind, ind + 1, ":");
         }
-        return ext.toString();
+
+        return ext.insert(0, rootPrefix(target)).toString();
     }
 
     public static Set<String> targets(final Set<Target> deps) {
@@ -53,11 +56,11 @@ public abstract class BuckRuleComposer {
     }
 
     public static String targets(final Target dep) {
-        return String.format("//%s:src_%s", dep.getPath(), dep.getName());
+        return String.format("%s%s:src_%s", rootPrefix(dep), dep.getPath(), dep.getName());
     }
 
     public static String binTargets(final Target dep) {
-        return String.format("//%s:bin_%s", dep.getPath(), dep.getName());
+        return String.format("%s%s:bin_%s", rootPrefix(dep), dep.getPath(), dep.getName());
     }
 
     public static String toLocation(final List<String> targets) {
@@ -72,5 +75,27 @@ public abstract class BuckRuleComposer {
 
     public static String toClasspath(final String target) {
         return "$(classpath " + target + ")";
+    }
+
+    public static String rootPrefix(final Target target) {
+        return "//" + relativeRoot(target.getRootProject());
+    }
+
+    public static String relativeRoot(Project project) {
+        File projectRoot = project.getRootDir();
+        File buckRoot = (File) ProjectUtil.getExtProperty(project, "buckRootDirectory");
+
+        if (projectRoot.equals(buckRoot)) {
+            return "";
+        } else if (!isParent(buckRoot, projectRoot)) {
+            throw new IllegalStateException(
+                    "The buck root dir must be the same dir or parent of the okbuck project/target dir.");
+        }
+
+        return buckRoot.toURI().relativize(projectRoot.toURI()).toString();
+    }
+
+    private static boolean isParent(File parent, File possibleChild) {
+        return possibleChild.getAbsolutePath().startsWith(parent.getAbsolutePath());
     }
 }

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/groovy/GroovyLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/groovy/GroovyLibraryRuleComposer.groovy
@@ -14,16 +14,16 @@ final class GroovyLibraryRuleComposer extends JvmBuckRuleComposer {
 
     static GroovyLibraryRule compose(GroovyLibTarget target) {
         List<String> deps = []
-        deps.addAll(external(target.main.externalDeps))
+        deps.addAll(external(target.main.externalDeps, target))
         deps.addAll(targets(target.main.targetDeps))
 
         Set<String> providedDeps = []
-        providedDeps.addAll(external(target.provided.externalDeps))
+        providedDeps.addAll(external(target.provided.externalDeps, target))
         providedDeps.addAll(targets(target.provided.targetDeps))
         providedDeps.removeAll(deps)
 
         if (target.retrolambda) {
-            providedDeps.add(RetrolambdaUtil.getRtStubJarRule())
+            providedDeps.add(RetrolambdaUtil.getRtStubJarRule(target))
         }
 
         new GroovyLibraryRule(

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/groovy/GroovyTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/groovy/GroovyTestRuleComposer.groovy
@@ -15,16 +15,16 @@ final class GroovyTestRuleComposer extends JvmBuckRuleComposer {
     static GroovyTestRule compose(GroovyLibTarget target) {
         List<String> deps = []
         deps.add(":${src(target)}")
-        deps.addAll(external(target.test.externalDeps))
+        deps.addAll(external(target.test.externalDeps, target))
         deps.addAll(targets(target.test.targetDeps))
 
         Set<String> providedDeps = []
-        providedDeps.addAll(external(target.testProvided.externalDeps))
+        providedDeps.addAll(external(target.testProvided.externalDeps, target))
         providedDeps.addAll(targets(target.testProvided.targetDeps))
         providedDeps.removeAll(deps)
 
         if (target.retrolambda) {
-            providedDeps.add(RetrolambdaUtil.getRtStubJarRule())
+            providedDeps.add(RetrolambdaUtil.getRtStubJarRule(target))
         }
 
         new GroovyTestRule(

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/java/JavaLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/java/JavaLibraryRuleComposer.groovy
@@ -14,20 +14,20 @@ final class JavaLibraryRuleComposer extends JvmBuckRuleComposer {
 
     static JavaLibraryRule compose(JavaLibTarget target) {
         List<String> deps = []
-        deps.addAll(external(target.main.externalDeps))
+        deps.addAll(external(target.main.externalDeps, target))
         deps.addAll(targets(target.main.targetDeps))
 
         Set<String> aptDeps = [] as Set
-        aptDeps.addAll(externalApt(target.apt.externalDeps))
+        aptDeps.addAll(externalApt(target.apt.externalDeps, target))
         aptDeps.addAll(targetsApt(target.apt.targetDeps))
 
         Set<String> providedDeps = []
-        providedDeps.addAll(external(target.provided.externalDeps))
+        providedDeps.addAll(external(target.provided.externalDeps, target))
         providedDeps.addAll(targets(target.provided.targetDeps))
         providedDeps.removeAll(deps)
 
         if (target.retrolambda) {
-            providedDeps.add(RetrolambdaUtil.getRtStubJarRule())
+            providedDeps.add(RetrolambdaUtil.getRtStubJarRule(target))
         }
 
         List<String> testTargets = []

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/java/JavaTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/java/JavaTestRuleComposer.groovy
@@ -15,20 +15,20 @@ final class JavaTestRuleComposer extends JvmBuckRuleComposer {
     static JavaTestRule compose(JavaLibTarget target) {
         List<String> deps = []
         deps.add(":${src(target)}")
-        deps.addAll(external(target.test.externalDeps))
+        deps.addAll(external(target.test.externalDeps, target))
         deps.addAll(targets(target.test.targetDeps))
 
         Set<String> aptDeps = [] as Set
-        aptDeps.addAll(external(target.testApt.externalDeps))
+        aptDeps.addAll(external(target.testApt.externalDeps, target))
         aptDeps.addAll(targets(target.testApt.targetDeps))
 
         Set<String> providedDeps = []
-        providedDeps.addAll(external(target.testProvided.externalDeps))
+        providedDeps.addAll(external(target.testProvided.externalDeps, target))
         providedDeps.addAll(targets(target.testProvided.targetDeps))
         providedDeps.removeAll(deps)
 
         if (target.retrolambda) {
-            providedDeps.add(RetrolambdaUtil.getRtStubJarRule())
+            providedDeps.add(RetrolambdaUtil.getRtStubJarRule(target))
         }
 
         new JavaTestRule(

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/kotlin/KotlinLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/kotlin/KotlinLibraryRuleComposer.groovy
@@ -14,11 +14,11 @@ final class KotlinLibraryRuleComposer extends JvmBuckRuleComposer {
 
     static JavaLibraryRule compose(KotlinLibTarget target) {
         List<String> deps = []
-        deps.addAll(external(target.main.externalDeps))
+        deps.addAll(external(target.main.externalDeps, target))
         deps.addAll(targets(target.main.targetDeps))
 
         Set<String> providedDeps = []
-        providedDeps.addAll(external(target.provided.externalDeps))
+        providedDeps.addAll(external(target.provided.externalDeps, target))
         providedDeps.addAll(targets(target.provided.targetDeps))
         providedDeps.removeAll(deps)
 

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/kotlin/KotlinTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/kotlin/KotlinTestRuleComposer.groovy
@@ -15,11 +15,11 @@ final class KotlinTestRuleComposer extends JvmBuckRuleComposer {
     static JavaTestRule compose(KotlinLibTarget target) {
         List<String> deps = []
         deps.add(":${src(target)}")
-        deps.addAll(external(target.test.externalDeps))
+        deps.addAll(external(target.test.externalDeps, target))
         deps.addAll(targets(target.test.targetDeps))
 
         Set<String> providedDeps = []
-        providedDeps.addAll(external(target.testProvided.externalDeps))
+        providedDeps.addAll(external(target.testProvided.externalDeps, target))
         providedDeps.addAll(targets(target.testProvided.targetDeps))
         providedDeps.removeAll(deps)
 

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/LintUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/LintUtil.java
@@ -1,7 +1,9 @@
 package com.uber.okbuck.core.util;
 
 import com.uber.okbuck.OkBuckGradlePlugin;
+import com.uber.okbuck.composer.base.BuckRuleComposer;
 import com.uber.okbuck.core.dependency.DependencyCache;
+import com.uber.okbuck.core.model.base.Target;
 import com.uber.okbuck.extension.OkBuckExtension;
 
 import org.apache.commons.io.FileUtils;
@@ -24,8 +26,6 @@ public final class LintUtil {
     private static final String LINT_DEPS_CACHE = OkBuckGradlePlugin.DEFAULT_CACHE_PATH + "/lint";
     private static final String LINT_VERSION_FILE = LINT_DEPS_CACHE + "/.lintVersion";
     private static final String LINT_DEPS_BUCK_FILE = "lint/BUCK_FILE";
-
-    public static final String LINT_DEPS_RULE = "//" + LINT_DEPS_CACHE + ":okbuck_lint";
 
     private LintUtil() {}
 
@@ -67,19 +67,19 @@ public final class LintUtil {
         getLintDepsCache(project);
     }
 
-    private static String getLintwConfigName(Project project, File config) {
-        return FileUtil.getRelativePath(project.getRootDir(), config).replaceAll("/", "_");
+    private static String getLintwConfigName(Target target, File config) {
+        return FileUtil.getRelativePath(target.getRootProject().getRootDir(), config).replaceAll("/", "_");
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    public static synchronized String getLintwConfigRule(Project project, File config) {
-        File configFile = project.getRootProject().file(LINT_DEPS_CACHE + "/" + getLintwConfigName(project, config));
+    public static synchronized String getLintwConfigRule(Target target, File config) {
+        File configFile = target.getRootProject().file(LINT_DEPS_CACHE + "/" + getLintwConfigName(target, config));
         try {
             FileUtils.copyFile(config, configFile);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        return "//" + LINT_DEPS_CACHE + ":" + getLintwConfigName(project, config);
+        return BuckRuleComposer.rootPrefix(target) + LINT_DEPS_CACHE + ":" + getLintwConfigName(target, config);
     }
 
     public static DependencyCache getLintDepsCache(Project project) {
@@ -99,5 +99,9 @@ public final class LintUtil {
                     okBuckExtension.buckProjects);
         }
         return okBuckGradlePlugin.lintDepCache;
+    }
+
+    public static String getLintDepsRule(Target target) {
+        return BuckRuleComposer.rootPrefix(target) + LINT_DEPS_CACHE + ":okbuck_lint";
     }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
@@ -60,4 +60,8 @@ public final class ProjectUtil {
     private static TargetCache getTargetCache(Project project) {
         return getPlugin(project).targetCache;
     }
+
+    public static Object getExtProperty(Project project, String propname) {
+        return project.getRootProject().getExtensions().getExtraProperties().get(propname);
+    }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/RetrolambdaUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/RetrolambdaUtil.java
@@ -2,9 +2,12 @@ package com.uber.okbuck.core.util;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+
 import com.uber.okbuck.OkBuckGradlePlugin;
+import com.uber.okbuck.composer.base.BuckRuleComposer;
 import com.uber.okbuck.core.dependency.DependencyCache;
 import com.uber.okbuck.core.model.base.Scope;
+import com.uber.okbuck.core.model.base.Target;
 import com.uber.okbuck.extension.RetrolambdaExtension;
 
 import org.apache.commons.lang.StringUtils;
@@ -30,8 +33,8 @@ public final class RetrolambdaUtil {
 
     private RetrolambdaUtil() {}
 
-    public static String getRtStubJarRule() {
-        return "//" + RETROLAMDBA_CACHE + ":" + RT_STUB_JAR;
+    public static String getRtStubJarRule(final Target target) {
+        return BuckRuleComposer.rootPrefix(target) + RETROLAMDBA_CACHE + ":" + RT_STUB_JAR;
     }
 
     public static void fetchRetrolambdaDeps(Project project, RetrolambdaExtension extension) {
@@ -64,7 +67,7 @@ public final class RetrolambdaUtil {
         if (!StringUtils.isEmpty(extension.jvmArgs)) {
             builder = builder.add(extension.jvmArgs);
         }
-        builder = builder.add("-jar").add(retrolambdaJar + ")").add("<<<");
+        builder = builder.add("-jar").add(BuckRuleComposer.relativeRoot(project) + retrolambdaJar + ")").add("<<<");
         ProjectUtil.getPlugin(project).retrolambdaCmd = Joiner.on(" ").join(builder.build());
     }
 


### PR DESCRIPTION
This introduces the concept of the buck root directory to okbuck. The buck root directory is where buck itself will be invoked from, therefore all the build rules need to be specified from this root. OkBuck still runs relative to the specified gradle working directory. 

I'm not sure if `project.ext` was the best place to store the root directory, as I'm a bit unfamiliar with gradle plugin best practices, open to suggestions (as well as naming suggestions, etc.).

In most cases I plumbed the `Target` through, also not sure if this is most appropriate but since it is available as the source of most of the build rules anyway it felt okay.

@kageiit 