### PR TITLE
Add option to easily publish to maven repo

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -52,6 +52,19 @@ version = publishVersion
 def siteUrl = 'https://github.com/uber/okbuck'
 def gitUrl = 'https://github.com/uber/okbuck.git'
 
+def getReleaseRepositoryUrl() {
+  return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
+      : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+}
+
+def getRepositoryUsername() {
+  return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
+}
+
+def getRepositoryPassword() {
+  return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
@@ -62,6 +75,16 @@ publishing {
 
             artifactId 'okbuck'
         }
+    }
+    repositories {
+      maven {
+        name 'release'
+        url getReleaseRepositoryUrl()
+        credentials {
+          username getRepositoryUsername()
+          password getRepositoryPassword()
+        }
+      }
     }
 }
 


### PR DESCRIPTION
This just adds a few functions so that it's easy to publish to a maven repo with `./gradlew publish` (some of the logic from https://github.com/chrisbanes/gradle-mvn-push/blob/master/gradle-mvn-push.gradle), probably for internal releases.

`./gradlew bintrayUpload` should still work fine as before

cc @kageiit 