### PR TITLE
Use stream instead of parallelStream

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/base/BuckRuleComposer.java
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/base/BuckRuleComposer.java
@@ -14,13 +14,13 @@ public abstract class BuckRuleComposer {
     private static final String SEPARATOR = ":";
 
     public static Set<String> external(final Set<String> deps) {
-        return deps.parallelStream()
+        return deps.stream()
                 .map(BuckRuleComposer::fileRule)
                 .collect(Collectors.toSet());
     }
 
     public static Set<String> externalApt(final Set<String> deps) {
-        return external(deps).parallelStream()
+        return external(deps).stream()
                 .filter(dep -> dep.endsWith(".jar"))
                 .collect(Collectors.toSet());
     }
@@ -40,13 +40,13 @@ public abstract class BuckRuleComposer {
     }
 
     public static Set<String> targets(final Set<Target> deps) {
-        return deps.parallelStream()
+        return deps.stream()
                 .map(BuckRuleComposer::targets)
                 .collect(Collectors.toSet());
     }
 
     public static Set<String> targetsApt(final Set<Target> deps) {
-        return deps.parallelStream()
+        return deps.stream()
                 .filter(target -> target.getClass().equals(JavaLibTarget.class))
                 .map(BuckRuleComposer::targets)
                 .collect(Collectors.toSet());
@@ -61,7 +61,7 @@ public abstract class BuckRuleComposer {
     }
 
     public static String toLocation(final List<String> targets) {
-        return targets.parallelStream()
+        return targets.stream()
                 .map(BuckRuleComposer::toLocation)
                 .collect(Collectors.joining(SEPARATOR));
     }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckCleanTask.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckCleanTask.java
@@ -61,7 +61,7 @@ public class OkBuckCleanTask extends DefaultTask {
 
         // Delete stale project's BUCK file
         difference
-                .parallelStream()
+                .stream()
                 .map(p -> rootProjectPath.resolve(p).resolve(OkBuckGradlePlugin.BUCK))
                 .forEach(FileUtil::deleteQuietly);
 

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/FileUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/FileUtil.java
@@ -55,7 +55,7 @@ public final class FileUtil {
         if (files == null || files.isEmpty()) {
             return Collections.emptySet();
         }
-        return files.parallelStream()
+        return files.stream()
                 .filter(f -> Objects.nonNull(f) && f.exists())
                 .map(f -> getRelativePath(project.getProjectDir(), f))
                 .collect(Collectors.toCollection(LinkedHashSet::new));

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/KotlinUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/KotlinUtil.java
@@ -32,7 +32,7 @@ public final class KotlinUtil {
                 .getByName("classpath")
                 .getResolvedConfiguration()
                 .getResolvedArtifacts()
-                .parallelStream()
+                .stream()
                 .filter(resolvedArtifact -> {
                     ModuleVersionIdentifier identifier = resolvedArtifact.getModuleVersion().getId();
                     return (KOTLIN_GROUP.equals(identifier.getGroup()) &&

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/LintUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/LintUtil.java
@@ -36,7 +36,7 @@ public final class LintUtil {
                 .getByName("classpath")
                 .getResolvedConfiguration()
                 .getResolvedArtifacts()
-                .parallelStream()
+                .stream()
                 .filter(resolvedArtifact -> {
                     ModuleVersionIdentifier identifier = resolvedArtifact.getModuleVersion().getId();
                     return (LINT_GROUP.equals(identifier.getGroup()) && LINT_MODULE.equals(identifier.getName()));

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/ProguardUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/ProguardUtil.java
@@ -45,7 +45,7 @@ public final class ProguardUtil {
                 .getByName("classpath")
                 .getResolvedConfiguration()
                 .getResolvedArtifacts()
-                .parallelStream()
+                .stream()
                 .filter(ProguardUtil::findProguard)
                 .findFirst()
                 .map(r -> r.getModuleVersion().getId().getVersion())

--- a/buildSrc/src/main/java/com/uber/okbuck/wrapper/BuckWrapperTask.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/wrapper/BuckWrapperTask.java
@@ -1,7 +1,6 @@
 package com.uber.okbuck.wrapper;
 
 import com.google.common.collect.ImmutableMap;
-
 import com.uber.okbuck.OkBuckGradlePlugin;
 import com.uber.okbuck.core.util.FileUtil;
 
@@ -13,12 +12,12 @@ import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @SuppressWarnings({"WeakerAccess", "CanBeFinal", "unused", "ResultOfMethodCallIgnored", "NewApi"})
 public class BuckWrapperTask extends DefaultTask {
@@ -70,7 +69,7 @@ public class BuckWrapperTask extends DefaultTask {
         }
 
         String ignoreExprs = ignoredDirs
-                .parallelStream()
+                .stream()
                 .map(ignoredDir -> "            [\"dirname\", \"" + ignoredDir + "\"]")
                 .collect(Collectors.joining(",\n"));
 
@@ -102,25 +101,24 @@ public class BuckWrapperTask extends DefaultTask {
         }
 
         String matchExprs = matches
-                .parallelStream()
+                .stream()
                 .map(match -> "            [\"match\", \"" + match + "\", \"wholename\"]")
                 .collect(Collectors.joining(",\n"));
 
         String suffixExprs = suffixes
-                .parallelStream()
+                .stream()
                 .map(suffix -> "            [\"suffix\", \"" + suffix + "\"]")
                 .collect(Collectors.joining(",\n"));
 
         String nameExpr = names
-                .parallelStream()
+                .stream()
                 .map(name -> "\"" + name + "\"")
                 .collect(Collectors.joining(", "));
         if (!nameExpr.isEmpty()) {
             nameExpr = "            [\"name\", [" + nameExpr + "]]";
         }
 
-        return Arrays.asList(suffixExprs, nameExpr, matchExprs)
-                .parallelStream()
+        return Stream.of(suffixExprs, nameExpr, matchExprs)
                 .filter(StringUtils::isNotEmpty)
                 .collect(Collectors.joining(",\n"));
     }


### PR DESCRIPTION
The overhead of creating threads for very small tasks might not be
faster than performing the same tasks serially.

I ran a benchmark using this commit against our repo. I killed the
gradle daemon and then ran the okbuck task 3 times.

Before: using parallel()
20.353 secs
6.644 secs
5.89 secs

After: using stream()
18.539 secs
6.316 secs
5.613 secs

The results were quite similar with and without parallel stream. I'm
wondering if there is any noticeable difference with even larger projects.