### PR TITLE
Add empty resource rule if using resource union.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     compile deps.external.xlogAndroidIdle
     compile deps.apt.autoValue
 
+    compile project(':libraries:emptyResourceLibrary')
     compile project(':libraries:emptylibrary')
     devCompile project(path: ':dummylibrary', configuration: 'freeRelease')
     prodCompile project(path: ':dummylibrary', configuration: 'paidRelease')

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/android/AndroidResourceRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/android/AndroidResourceRule.groovy
@@ -22,7 +22,7 @@ final class AndroidResourceRule extends BuckRule {
     @Override
     protected final void printContent(PrintStream printer) {
         printer.println("\tpackage = '${mPackage}',")
-        if (mRes) {
+        if (mRes || mResourceUnion) {
             printer.println("\tres = res_glob([")
             mRes.each {
                 printer.println("\t\t('${it}', '**'),")

--- a/libraries/emptyResourceLibrary/build.gradle
+++ b/libraries/emptyResourceLibrary/build.gradle
@@ -1,0 +1,6 @@
+apply plugin: 'com.android.library'
+
+dependencies {
+    compile project(':libraries:emptylibrary')
+    compile deps.support.appCompat
+}

--- a/libraries/emptyResourceLibrary/src/main/AndroidManifest.xml
+++ b/libraries/emptyResourceLibrary/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.uber.okbuck.library.empty.resources"/>

--- a/libraries/emptyResourceLibrary/src/main/java/com/uber/okbuck/library/empty/resources/Test.java
+++ b/libraries/emptyResourceLibrary/src/main/java/com/uber/okbuck/library/empty/resources/Test.java
@@ -1,0 +1,10 @@
+package com.uber.okbuck.library.empty.resources;
+
+import android.content.Context;
+
+public class Test {
+
+  public String foo(Context context) {
+    return context.getString(R.string.empty_release_string);
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 include 'app'
 include 'another-app'
 include 'dummylibrary'
+include 'libraries:emptyResourceLibrary'
 include 'libraries:common'
 include 'libraries:customLintLibrary'
 include 'libraries:emptylibrary'


### PR DESCRIPTION
This ensures that an R file is created for that module even if there are
no resources. Gradle always generates an R file for each module even if
there are no resources.