### PR TITLE
Preserve tools:overrideLibrary in <uses-sdk>

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidTarget.groovy
@@ -240,14 +240,16 @@ abstract class AndroidTarget extends JavaLibTarget {
     }
 
     String processManifestXml(GPathResult manifestXml) {
-        def sdkNode = {
-            'uses-sdk'('android:minSdkVersion': String.valueOf(minSdk),
-                    'android:targetSdkVersion': String.valueOf(targetSdk)) {}
-        }
         if (manifestXml.'uses-sdk'.size() == 0) {
-            manifestXml.appendNode(sdkNode)
+            manifestXml.appendNode {
+                'uses-sdk'('android:minSdkVersion': String.valueOf(minSdk), 'android:targetSdkVersion': String.valueOf(targetSdk)) {}
+            }
         } else {
-            manifestXml.'uses-sdk'.replaceNode(sdkNode)
+            def overrideLibrary = manifestXml.'uses-sdk'.@'tools:overrideLibrary'
+            manifestXml.'uses-sdk'.replaceNode {
+                'uses-sdk'('android:minSdkVersion': String.valueOf(minSdk), 'android:targetSdkVersion': String.valueOf(targetSdk),
+                    'xmlns:tools':'http://schemas.android.com/tools', 'tools:overrideLibrary': overrideLibrary) {}
+            }
         }
 
         def builder = new StreamingMarkupBuilder()

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidTarget.groovy
@@ -312,7 +312,7 @@ abstract class AndroidTarget extends JavaLibTarget {
 
     private void parseManifest(String originalManifest, File mergedManifest) {
         XmlSlurper slurper = new XmlSlurper()
-        GPathResult manifestXml = slurper.parseText(originalManifest).declareNamespace(android: 'http://schemas.android.com/apk/res/android')
+        GPathResult manifestXml = slurper.parseText(originalManifest)
         packageName = manifestXml.@package
 
         String processedManifest = processManifestXml(manifestXml)

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidTarget.groovy
@@ -244,11 +244,15 @@ abstract class AndroidTarget extends JavaLibTarget {
             manifestXml.appendNode {
                 'uses-sdk'('android:minSdkVersion': String.valueOf(minSdk), 'android:targetSdkVersion': String.valueOf(targetSdk)) {}
             }
-        } else {
+        } else if (manifestXml.'uses-sdk'.@'tools:overrideLibrary'.size() > 0) {
             def overrideLibrary = manifestXml.'uses-sdk'.@'tools:overrideLibrary'
             manifestXml.'uses-sdk'.replaceNode {
                 'uses-sdk'('android:minSdkVersion': String.valueOf(minSdk), 'android:targetSdkVersion': String.valueOf(targetSdk),
                     'xmlns:tools':'http://schemas.android.com/tools', 'tools:overrideLibrary': overrideLibrary) {}
+            }
+        } else {
+            manifestXml.'uses-sdk'.replaceNode {
+                'uses-sdk'('android:minSdkVersion': String.valueOf(minSdk), 'android:targetSdkVersion': String.valueOf(targetSdk)) {}
             }
         }
 

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidTarget.groovy
@@ -16,11 +16,13 @@ import com.uber.okbuck.core.model.base.Scope
 import com.uber.okbuck.core.model.java.JavaLibTarget
 import com.uber.okbuck.core.model.jvm.TestOptions
 import com.uber.okbuck.core.util.FileUtil
+import groovy.lang.Closure
 import groovy.util.slurpersupport.GPathResult
 import groovy.xml.StreamingMarkupBuilder
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.Test
 
 import java.nio.file.Paths
@@ -240,7 +242,7 @@ abstract class AndroidTarget extends JavaLibTarget {
     }
 
     String processManifestXml(GPathResult manifestXml) {
-        def sdkNode = getSdkNode(manifestXml)
+        def sdkNode = getSdkNode(manifestXml, minSdk, targetSdk)
         if (manifestXml.'uses-sdk'.size() == 0) {
             manifestXml.appendNode(sdkNode)
         } else {
@@ -255,16 +257,6 @@ abstract class AndroidTarget extends JavaLibTarget {
                 .replaceAll('\\{http://schemas.android.com/apk/res/android\\}', 'android:')
                 .replaceAll('xmlns:android="http://schemas.android.com/apk/res/android"', '')
                 .replaceFirst('<manifest ', '<manifest xmlns:android="http://schemas.android.com/apk/res/android" ')
-    }
-
-    private groovy.lang.Closure getSdkNode(GPathResult manifestXml) {
-        def sdkAttributes = manifestXml.'uses-sdk'.'**'*.attributes()[0] ?: [:]
-        sdkAttributes['{http://schemas.android.com/apk/res/android}minSdkVersion'] = String.valueOf(minSdk)
-        sdkAttributes['{http://schemas.android.com/apk/res/android}targetSdkVersion'] = String.valueOf(targetSdk)
-
-        return {
-            'uses-sdk'(sdkAttributes) {}
-        }
     }
 
     private void ensureManifest() {
@@ -337,6 +329,16 @@ abstract class AndroidTarget extends JavaLibTarget {
                 options.remove(index + 1)
                 options.remove(index)
             }
+        }
+    }
+
+    private static Closure getSdkNode(GPathResult manifestXml, int minSdk, int targetSdk) {
+        def sdkAttributes = manifestXml.'uses-sdk'.'**'*.attributes()[0] ?: [:]
+        sdkAttributes['{http://schemas.android.com/apk/res/android}minSdkVersion'] = String.valueOf(minSdk)
+        sdkAttributes['{http://schemas.android.com/apk/res/android}targetSdkVersion'] = String.valueOf(targetSdk)
+
+        return {
+            'uses-sdk'(sdkAttributes) {}
         }
     }
 


### PR DESCRIPTION
okbuck currently replaces whole <uses-sdk> tag and overrides potential tools:overrideLibrary