### PR TITLE
Do not allow snapshot/dynamic dependencies in okbuck

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     apply from: rootProject.file('dependencies.gradle')
     repositories {
         jcenter()
+        google()
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
@@ -18,6 +19,7 @@ allprojects { project ->
     project.apply from: rootProject.file('dependencies.gradle')
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -8,6 +8,7 @@ apply from: "../dependencies.gradle"
 
 repositories {
     jcenter()
+    google()
 }
 
 tasks.withType(GroovyCompile) {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/DependencyCache.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/DependencyCache.groovy
@@ -4,6 +4,7 @@ import com.uber.okbuck.core.util.FileUtil
 import groovy.transform.Synchronized
 import org.apache.commons.io.IOUtils
 import org.gradle.api.Project
+import org.gradle.api.artifacts.ComponentSelection
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.plugins.ide.internal.IdeDependenciesExtractor
@@ -193,6 +194,15 @@ class DependencyCache {
                 !(it instanceof org.gradle.api.artifacts.ProjectDependency)
             })
         }
+
+        superConfiguration.resolutionStrategy.componentSelection.all { ComponentSelection selection ->
+            String version = selection.candidate.version
+            if (version.contains("-SNAPSHOT") || version.contains("+")) {
+                throw new IllegalStateException("Please do not use snapshot/dynamic version dependencies. They can " +
+                        "cause hard to reproduce builds")
+            }
+        }
+
         return superConfiguration
     }
 

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
@@ -86,6 +86,12 @@ public class OkBuckExtension {
     @Input
     public Set<String> extraDepCaches = new HashSet<>();
 
+    /**
+    * Forces okbuck to fail if the project is using dynamic or snapshot dependencies
+    */
+    @Input
+    public boolean failOnChangingDependencies = false;
+
     public OkBuckExtension(Project project) {
         buckProjects = project.getSubprojects();
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-4.0-milestone-2-bin.zip

--- a/libraries/groovylibrary/build.gradle
+++ b/libraries/groovylibrary/build.gradle
@@ -2,10 +2,6 @@ plugins {
     id "groovy"
 }
 
-repositories {
-    jcenter()
-}
-
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.7'
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
This makes it safer for the sake of hermetic builds by surfacing any dynamically versioned dependencies to users

- By default a warning is printed, but it can be made an error by setting `failOnChangingDependencies` in the `okbuck` extension. This behavior will be made to always error on a subsequent release
- Also updated gradle to latest