### PR TITLE
Switch the ordering of build config fields.

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidTarget.groovy
@@ -177,11 +177,11 @@ abstract class AndroidTarget extends JavaLibTarget {
 
         Map<String, ClassField> extraBuildConfig = [:]
 
-        baseVariant.buildType.buildConfigFields.collect { String key, ClassField classField ->
+        baseVariant.mergedFlavor.buildConfigFields.collect { String key, ClassField classField ->
             extraBuildConfig.put(key, classField)
         }
 
-        baseVariant.mergedFlavor.buildConfigFields.collect { String key, ClassField classField ->
+        baseVariant.buildType.buildConfigFields.collect { String key, ClassField classField ->
             extraBuildConfig.put(key, classField)
         }
 


### PR DESCRIPTION
In the below example, we would expect the final value to be false, but instead it is true.

```
android {
  defaultConfig {
    buildConfigField "boolean", "VALUE", "true"
  }

  buildTypes {
    debug {
      buildConfigField "boolean", "VALUE", "false"
    }
  }
}
```
With the order switched, it uses the expected value of false instead of true. In Gradle, the result is always false. Gradle prefers to use the build type value over the default.