### PR TITLE
Add option to exclude some resources from aapt

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
@@ -1,5 +1,8 @@
 package com.uber.okbuck.core.task;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+
 import com.uber.okbuck.OkBuckGradlePlugin;
 import com.uber.okbuck.core.model.base.ProjectType;
 import com.uber.okbuck.core.util.FileUtil;
@@ -87,7 +90,12 @@ public class OkBuckTask extends DefaultTask {
     }
 
     // Setup defs
-    FileUtil.copyResourceToProject("defs/OKBUCK_DEFS", okbuckDefs());
+    FileUtil.copyResourceToProject("defs/OKBUCK_DEFS_TEMPLATE", okbuckDefs(),
+            ImmutableMap.of("template-resource-excludes", Joiner.on(", ")
+                    .join(okBuckExtension.excludeResources
+                            .stream()
+                            .map(s -> "'" + s + "'")
+                            .collect(Collectors.toSet()))));
     Set<String> defs = okbuckExt.extraDefs.stream()
             .map(it -> "//" + FileUtil.getRelativePath(getProject().getRootDir(), it))
             .collect(Collectors.toSet());

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
@@ -79,6 +79,12 @@ public class OkBuckExtension {
     public boolean resourceUnion = true;
 
     /**
+     * List of exclude patterns for resources to be processed by aapt
+     */
+    @Input
+    public Set<String> excludeResources = new HashSet<>();
+
+    /**
      * Additional dependency caches.
      * Every entry will create a new configuration "entryDepCache"
      * that can be used to fetch and cache dependencies.

--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/defs/OKBUCK_DEFS_TEMPLATE
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/defs/OKBUCK_DEFS_TEMPLATE
@@ -26,6 +26,7 @@ def res_glob(glob_specs):
     results = {}
 
     for dirpath, glob_pattern in glob_specs:
-        results[dirpath] = subdir_glob([(dirpath, glob_pattern)])
+        results[dirpath] = subdir_glob([(dirpath, glob_pattern)], 
+        excludes=[${template-resource-excludes}])
 
     return merge_maps(**results)


### PR DESCRIPTION
This can speedup builds by excluding resource configs that are not usually used for debugging. This is similar to the gradle provided option `resConfigs`

https://developer.android.com/studio/build/shrink-code.html#unused-alt-resources