### PR TITLE
Setup Kotlin home whenever the kotlin gradle plugin is on the classpath.

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
@@ -13,7 +13,6 @@ import com.uber.okbuck.core.util.ProjectUtil;
 import com.uber.okbuck.extension.OkBuckExtension;
 import com.uber.okbuck.generator.DotBuckConfigLocalGenerator;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.Nested;
@@ -46,7 +45,7 @@ public class OkBuckTask extends DefaultTask {
     }
 
     // Fetch Kotlin support deps if needed
-    boolean hasKotlinLib = okBuckExtension.buckProjects.parallelStream().anyMatch(project -> ProjectUtil.getType(project) == ProjectType.KOTLIN_LIB);
+    boolean hasKotlinLib = KotlinUtil.hasKotlinPluginInClasspath(getProject());
     if (hasKotlinLib) {
       KotlinUtil.setupKotlinHome(getProject());
     }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/KotlinUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/KotlinUtil.java
@@ -62,4 +62,8 @@ public final class KotlinUtil {
             });
         } catch (IOException ignored) {}
     }
+
+    public static boolean hasKotlinPluginInClasspath(Project project) {
+        return ProjectUtil.findVersionInClasspath(project, KOTLIN_GROUP, KOTLIN_GRADLE_MODULE) != null;
+    }
 }


### PR DESCRIPTION
Previously we should only check if a module was a kotlin module which
didn't account for kotlin-android modules.