### PR TITLE
Allow transform config to accept project dependencies

### DIFF
--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/transform/BUCK_FILE
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/transform/BUCK_FILE
@@ -22,7 +22,7 @@ for jar in jars:
 
 java_binary(
   name='okbuck_transform',
-  deps=map(lambda x: ":" + x, jars),
+  deps=map(lambda x: ":" + x, jars) + [${template-target-deps}],
   blacklist=[
     'META-INF',
   ],


### PR DESCRIPTION
This allows transforms written as part of buildSrc or as another project to be utilized as a dependency like

```
dependencies {
  transform project(":transform")
}
```