### PR TITLE
Skip OkBuck if we just want to run buck options.

### DIFF
--- a/buckw
+++ b/buckw
@@ -4,7 +4,7 @@
 ##
 ##  Buck wrapper script to invoke okbuck when needed, before running buck
 ##
-##  Created by OkBuck Gradle Plugin on : Thu Jul 13 10:40:45 PDT 2017
+##  Created by OkBuck Gradle Plugin on : Fri Jul 14 10:17:41 PDT 2017
 ##
 #########################################################################
 
@@ -213,10 +213,10 @@ setupBuckRun ( ) {
 
 # Handle parameters and flags
 handleParams ( ) {
-    # Go directly to kill. Do not run okbuck.
-    if [[ "kill" == $1 ]]; then
-        SKIP_OKBUCK=true
-    fi
+   # Go directly to the kill command, help command, or --help option. Do not run okbuck.
+   if [[ "kill" == $1 || "help" == $1 || $@ == *"--help"* || $@ == *"-h"* ]]; then
+      SKIP_OKBUCK=true
+   fi
 }
 
 handleParams "$@"

--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/wrapper/BUCKW_TEMPLATE
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/wrapper/BUCKW_TEMPLATE
@@ -204,10 +204,10 @@ setupBuckRun ( ) {
 
 # Handle parameters and flags
 handleParams ( ) {
-    # Go directly to kill. Do not run okbuck.
-    if [[ "kill" == $1 ]]; then
-        SKIP_OKBUCK=true
-    fi
+   # Go directly to the kill command, help command, or --help option. Do not run okbuck.
+   if [[ "kill" == $1 || "help" == $1 || $@ == *"--help"* || $@ == *"-h"* ]]; then
+      SKIP_OKBUCK=true
+   fi
 }
 
 handleParams "$@"


### PR DESCRIPTION
We shouldn't need to run the okbuck task if all we want to do is run `--help` on a buck command.