### PR TITLE
Set WORKING_DIR to the location of the buck wrapper.

### DIFF
--- a/buckw
+++ b/buckw
@@ -4,11 +4,11 @@
 ##
 ##  Buck wrapper script to invoke okbuck when needed, before running buck
 ##
-##  Created by OkBuck Gradle Plugin on : Mon Jul 10 10:22:56 PDT 2017
+##  Created by OkBuck Gradle Plugin on : Thu Jul 13 10:40:45 PDT 2017
 ##
 #########################################################################
 
-WORKING_DIR=$(pwd)
+WORKING_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 red=`tput setab 1 2>/dev/null || true`
 yellow=`tput setab 3 2>/dev/null || true`

--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/wrapper/BUCKW_TEMPLATE
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/wrapper/BUCKW_TEMPLATE
@@ -8,7 +8,7 @@
 ##
 #########################################################################
 
-WORKING_DIR=$(pwd)
+WORKING_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 red=`tput setab 1 2>/dev/null || true`
 yellow=`tput setab 3 2>/dev/null || true`


### PR DESCRIPTION
The IntellIj plugin attempts to run buck tests from within the module
where the test exists which causes the buck wrapper to fail locate the
gradle wrapper. Code taken from:
https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within/246128#246128