### PR TITLE
Broken test dependency resolution

### DIFF
--- a/libraries/common/build.gradle
+++ b/libraries/common/build.gradle
@@ -19,5 +19,8 @@ android {
 
 dependencies {
     compile deps.support.appCompat
+    compile deps.external.rxjava
     compile project(':libraries:parcelable')
+
+    testCompile deps.test.junit
 }

--- a/libraries/common/src/test/java/com/uber/okbuck/example/common/RxTest.java
+++ b/libraries/common/src/test/java/com/uber/okbuck/example/common/RxTest.java
@@ -1,0 +1,11 @@
+package com.uber.okbuck.example.common;
+
+import org.junit.Test;
+
+public class RxTest {
+
+    @Test
+    public void testRx() {
+        io.reactivex.Observable.just(1);
+    }
+}


### PR DESCRIPTION
"prod" dependencies are not added to test target dependencies:

release target dependencies
```
	deps = [
		'//.okbuck/cache:com.android.support.animated-vector-drawable-26.0.0-beta2.aar',
		'//.okbuck/cache:com.android.support.appcompat-v7-26.0.0-beta2.aar',
		'//.okbuck/cache:com.android.support.support-annotations-26.0.0-beta2.jar',
		'//.okbuck/cache:com.android.support.support-compat-26.0.0-beta2.aar',
		'//.okbuck/cache:com.android.support.support-core-ui-26.0.0-beta2.aar',
		'//.okbuck/cache:com.android.support.support-core-utils-26.0.0-beta2.aar',
		'//.okbuck/cache:com.android.support.support-fragment-26.0.0-beta2.aar',
		'//.okbuck/cache:com.android.support.support-media-compat-26.0.0-beta2.aar',
		'//.okbuck/cache:com.android.support.support-v4-26.0.0-beta2.aar',
		'//.okbuck/cache:com.android.support.support-vector-drawable-26.0.0-beta2.aar',
		'//.okbuck/cache:io.reactivex.rxjava2.rxjava-2.1.1.jar',
		'//.okbuck/cache:org.reactivestreams.reactive-streams-1.0.0.jar',
		'//libraries/parcelable:res_release',
		'//libraries/parcelable:src_release',
		':build_config_freeDebug',
		':freeDebug_src_main_aidl_aidls',
		':res_freeDebug',
	],
```

test target dependencies
```
	deps = [
		'//.okbuck/cache:junit.junit-4.12.jar',
		'//.okbuck/cache:org.hamcrest.hamcrest-core-1.3.jar',
		':build_config_freeDebug',
		':freeDebug_src_main_aidl_aidls',
		':res_freeDebug',
		':src_freeDebug',
	],
```