### PR TITLE
Add alternative approach to deal with dependency conflicts in android apps

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
@@ -26,8 +26,6 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 
-import java.nio.file.Paths
-
 // Dependency Tree
 //
 //                 okbuck
@@ -62,7 +60,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
     public static final String TRANSFORM = "transform"
     public static final String RETROLAMBDA = "retrolambda"
     public static final String SCALA = "scala"
-    public static final String CONFIGURATION_EXTERNAL = "externalOkbuck"
+    public static final String FORCED_OKBUCK = "forcedOkbuck"
     public static final String OKBUCK_DEFS = ".okbuck/defs/DEFS"
 
     public static final String OKBUCK_STATE_DIR = ".okbuck/state"
@@ -90,7 +88,8 @@ class OkBuckGradlePlugin implements Plugin<Project> {
 
         // Create configurations
         project.configurations.maybeCreate(TransformUtil.CONFIGURATION_TRANSFORM)
-        Configuration externalOkbuck = project.configurations.maybeCreate(CONFIGURATION_EXTERNAL)
+        Configuration forced = project.configurations.maybeCreate(FORCED_OKBUCK)
+        forced.transitive = false
 
         // Create tasks
         Task setupOkbuck = project.task('setupOkbuck')
@@ -136,7 +135,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
                 }
 
                 File cacheDir = DependencyUtils.createCacheDir(project, DEFAULT_CACHE_PATH, EXTERNAL_DEP_BUCK_FILE)
-                depCache = new DependencyCache(project, cacheDir)
+                depCache = new DependencyCache(project, cacheDir, FORCED_OKBUCK)
 
                 // Fetch Lint deps if needed
                 if (!lint.disabled && lint.version != null) {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/DependencyCache.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/DependencyCache.groovy
@@ -82,7 +82,7 @@ class DependencyCache {
 
     String get(ExternalDependency externalDependency, boolean resolveOnly = false) {
         ExternalDependency dependency =
-                forcedDeps.get(externalDependency.group + ":" + externalDependency.name, externalDependency)
+                forcedDeps.getOrDefault(externalDependency.group + ":" + externalDependency.name, externalDependency)
 
         File cachedCopy = new File(cacheDir, dependency.getCacheName(!resolveOnly))
         String key = FileUtil.getRelativePath(rootProject.projectDir, cachedCopy)

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/Scope.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/Scope.groovy
@@ -27,7 +27,7 @@ class Scope {
     DependencyCache depCache
 
     protected final Project project
-    protected final Set<ExternalDependency> external = [] as Set
+    final Set<ExternalDependency> external = [] as Set
 
     Scope(Project project,
           Collection<String> configurations,

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/ExternalDependency.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/ExternalDependency.java
@@ -41,11 +41,11 @@ public final class ExternalDependency {
 
     @Override
     public int hashCode() {
-        int result = version != null ? version.hashCode() : 0;
+        int result = (isLocal ? 1 : 0);
+        result = 31 * result + (version != null ? version.hashCode() : 0);
         result = 31 * result + (depFile != null ? depFile.hashCode() : 0);
         result = 31 * result + (group != null ? group.hashCode() : 0);
         result = 31 * result + (name != null ? name.hashCode() : 0);
-        result = 31 * result + (isLocal ? 1 : 0);
         return result;
     }
 

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
@@ -55,10 +55,6 @@ public final class ProjectUtil {
         return getTargetCache(targetProject).getTargetForOutput(targetProject, output);
     }
 
-    public static OkBuckExtension getExtension(Project project) {
-        return project.getRootProject().getExtensions().getByType(OkBuckExtension.class);
-    }
-
     static OkBuckGradlePlugin getPlugin(Project project) {
         return project.getRootProject().getPlugins().getPlugin(OkBuckGradlePlugin.class);
     }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -71,7 +71,7 @@ def test = [
         junit         : 'junit:junit:4.12',
         kotlinTest    : "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlinVersion}",
         mockito       : 'org.mockito:mockito-core:1.10.19',
-        robolectric   : 'org.robolectric:robolectric:3.4-rc2',
+        robolectric   : 'org.robolectric:robolectric:3.4',
         assertj       : 'org.assertj:assertj-core:3.8.0'
 ]
 


### PR DESCRIPTION
This enhances the approach detailed in https://github.com/uber/okbuck/wiki/Known-caveats#dependency-conflicts by providing an alternative way to force dependencies across all sub projects. This can be beneficial as gradle performance starts to degrade with many dependency substitution rules.

With the new approach, consumers can set forced versions of dependencies via

```
dependencies {
  forcedOkbuck "com.foo:bar:1.0.0"
}
```

To force all sub projects to use `1.0.0` of `com.foo:bar` regardless of what they pull in transitively