### PR TITLE
Create dependency cache symlinks during cleanup phase

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/Store.java
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/Store.java
@@ -24,8 +24,7 @@ public final class Store {
 
     private final Set<String> accessed;
     private final File storeFile;
-
-    public final Properties props;
+    private final Properties props;
 
     public Store(File storeFile) {
         this.storeFile = storeFile;

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/ProguardUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/ProguardUtil.java
@@ -49,7 +49,7 @@ public final class ProguardUtil {
                                 PROGUARD_GROUP,
                                 PROGUARD_MODULE,
                                 proguardVersion,
-                                artifactResult.get().getFile()));
+                                artifactResult.get().getFile()), true);
             }
         } catch (IllegalStateException ignored) {}
         return proguardJarPath;

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/RobolectricUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/RobolectricUtil.java
@@ -40,8 +40,9 @@ public final class RobolectricUtil {
         DependencyCache dependencyCache = new DependencyCache(project,
                 DependencyUtils.createCacheDir(project, ROBOLECTRIC_CACHE));
         for (Configuration configuration : runtimeDeps.build()) {
-            dependencyCache.build(configuration);
+            dependencyCache.build(configuration, false);
         }
+        dependencyCache.cleanup();
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
This moves the link creation step towards the finalization of the Dependency Cache's cleanup phase. Avoids a bunch of extra i/o and removes unnecessary thread safe collections to improve performance.

Also Fixes #497