### PR TITLE
Modify lint to not hit os limits of maximum argument length

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: true
 language: android
 jdk: oraclejdk8
 
+dist: precise
+
 android:
   components:
     - tools

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/base/BuckRuleComposer.java
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/base/BuckRuleComposer.java
@@ -75,4 +75,8 @@ public abstract class BuckRuleComposer {
     public static String toClasspath(final String target) {
         return "$(classpath " + target + ")";
     }
+
+    public static String toClasspathFile(final String target) {
+        return "$(@classpath " + target + ")";
+    }
 }


### PR DESCRIPTION
When running the lint cli on large apps, the transitive classpath passed into the --libraries option can get quite big and hit OS limits like MAX_ARG_STRLEN/ARG_MAX etc. This provides a workaround in okbuck till the issue can be fixed in lint by adding support for classpath argument files in https://issuetracker.google.com/issues/64683008