### PR TITLE
Add Robolectric support for API 26

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/RobolectricUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/RobolectricUtil.java
@@ -55,7 +55,8 @@ public final class RobolectricUtil {
         API_22("org.robolectric:android-all:5.1.1_r9-robolectric-1", null),
         API_23("org.robolectric:android-all:6.0.1_r3-robolectric-0", null),
         API_24("org.robolectric:android-all:7.0.0_r1-robolectric-0", null),
-        API_25("org.robolectric:android-all:7.1.0_r7-robolectric-0", null);
+        API_25("org.robolectric:android-all:7.1.0_r7-robolectric-0", null),
+        API_26("org.robolectric:android-all:o-preview-4-robolectric-0", null);
 
         private final String androidJar;
         private final String shadowsJar;


### PR DESCRIPTION
`o-preview-4-robolectric-0` appears to be the most recent version of `android-all`. Not sure if we want to wait for them to release 8.0 but this would at least add support for those beginning to target  API 26.