### PR TITLE
Begin migrating buck file generation to template engine

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "groovy"
     id "maven-publish"
     id "com.jfrog.bintray" version "1.7"
+    id "com.fizzed.rocker" version "0.22.0"
 }
 
 apply from: "../dependencies.gradle"
@@ -21,8 +22,9 @@ tasks.withType(JavaCompile) {
     targetCompatibility = '1.8'
 }
 
-sourceSets.main.java.srcDirs = []
+sourceSets.main.java.srcDirs = ["src/main/java/com/uber/okbuck/rule/base"]
 sourceSets.main.groovy.srcDirs = ["src/main/java", "src/main/groovy"]
+sourceSets.main.rocker.srcDirs = ["src/main/rocker", "src/main/java"]
 
 dependencies {
     compile gradleApi()
@@ -34,8 +36,16 @@ dependencies {
     compile deps.build.kotlinPlugin
     compile deps.build.mavenArtifact
     compile deps.build.okio
+    compile deps.build.rockerRuntime
 
     testCompile deps.test.junit
+}
+
+rocker {
+    discardLogicWhitespace true
+    optimize true
+    extendsClass "com.uber.okbuck.rule.base.RuleTemplate"
+    extendsModelClass "com.uber.okbuck.rule.base.Rule"
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/rule/base/GenRule.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/rule/base/GenRule.groovy
@@ -5,11 +5,7 @@ import com.uber.okbuck.core.model.base.RuleType
 
 final class GenRule extends BuckRule {
 
-    private final Set<String> inputs
-    private final Set<String> bashCmds
-    private final boolean globSrcs
-    private final String output
-    private final boolean executable
+    private final Rule genrule
 
     GenRule(String name,
             List<String> inputs,
@@ -18,31 +14,21 @@ final class GenRule extends BuckRule {
             String output = "${name}_out",
             boolean executable = false) {
         super(RuleType.GENRULE, name)
-        this.inputs = inputs
-        this.bashCmds = bashCmds
-        this.globSrcs = globSrcs
-        this.output = output
-        this.executable = executable
+        genrule = new template.base.GenRule()
+                .inputs(inputs)
+                .bashCmds(bashCmds.collect { it as String })
+                .globSrcs(globSrcs)
+                .output(output)
+                .executable(executable)
+                .ruleType(RuleType.GENRULE.name().toLowerCase())
+                .name(name)
     }
 
     @Override
-    final void printContent(Printer printer) {
-        if (!inputs.empty) {
-            printer.println(globSrcs ? "\tsrcs = glob([" : "\tsrcs = [")
-            for (String input : inputs) {
-                printer.println("\t\t'${input}',")
-            }
-            printer.println(globSrcs ? "\t])," : "\t],")
-        }
-
-        printer.println("\tout = '${output}',")
-        if (executable) {
-            printer.println("\texecutable = True,")
-        }
-        printer.println("\tbash = '' \\")
-        bashCmds.each {
-            printer.println("\t'${it} ' \\")
-        }
-        printer.println("\t'',")
+    void print(Printer printer) {
+        printer.println(genrule.render().toString())
     }
+
+    @Override
+    void printContent(Printer printer) {}
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/rule/base/Rule.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/rule/base/Rule.java
@@ -1,0 +1,40 @@
+package com.uber.okbuck.rule.base;
+
+import com.fizzed.rocker.runtime.DefaultRockerModel;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+public abstract class Rule<T extends Rule> extends DefaultRockerModel {
+
+    protected String ruleType;
+    protected String name;
+    protected Set<String> visibility = ImmutableSet.of();
+    protected Set<String> deps = ImmutableSet.of();
+    protected Set<String> extraBuckOpts = ImmutableSet.of();
+
+    public T ruleType(String ruleType) {
+        this.ruleType = ruleType;
+        return (T) this;
+    }
+
+    public T name(String name) {
+        this.name = name;
+        return (T) this;
+    }
+
+    public T deps(Set<String> deps) {
+        this.deps = deps;
+        return (T) this;
+    }
+
+    public T visibility(Set<String> visibility) {
+        this.visibility = visibility;
+        return (T) this;
+    }
+
+    public T extraBuckOpts(Set<String> extraBuckOpts) {
+        this.extraBuckOpts = extraBuckOpts;
+        return (T) this;
+    }
+}

--- a/buildSrc/src/main/java/com/uber/okbuck/rule/base/RuleTemplate.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/rule/base/RuleTemplate.java
@@ -1,0 +1,49 @@
+package com.uber.okbuck.rule.base;
+
+import com.fizzed.rocker.RockerModel;
+import com.fizzed.rocker.RockerTemplate;
+import com.fizzed.rocker.runtime.DefaultRockerTemplate;
+
+import java.util.Set;
+
+public abstract class RuleTemplate extends DefaultRockerTemplate {
+
+    protected String ruleType;
+    protected String name;
+    protected Set<String> visibility;
+    protected Set<String> deps;
+    protected Set<String> extraBuckOpts;
+
+    public RuleTemplate(RockerModel model) {
+        super(model);
+        if (model instanceof Rule) {
+            Rule rule = (Rule) model;
+            this.ruleType = rule.ruleType;
+            this.name = rule.name;
+            this.visibility = rule.visibility;
+            this.deps = rule.deps;
+            this.extraBuckOpts = rule.extraBuckOpts;
+        } else {
+            throw new IllegalArgumentException("Unable to create template (model was not an instance of " +
+                    Rule.class.getName() + ")");
+        }
+    }
+
+    @Override
+    protected void __associate(RockerTemplate context) {
+        super.__associate(context);
+
+        if (context instanceof RuleTemplate) {
+            RuleTemplate ninjaContext = (RuleTemplate)context;
+            this.ruleType = ninjaContext.ruleType;
+            this.name = ninjaContext.name;
+            this.visibility = ninjaContext.visibility;
+            this.deps = ninjaContext.deps;
+            this.extraBuckOpts = ninjaContext.extraBuckOpts;
+        }
+        else {
+            throw new IllegalArgumentException("Unable to associate (context was not an instance of " +
+                    RuleTemplate.class.getCanonicalName() + ")");
+        }
+    }
+}

--- a/buildSrc/src/main/rocker/template/base/BuckRule.rocker.raw
+++ b/buildSrc/src/main/rocker/template/base/BuckRule.rocker.raw
@@ -1,0 +1,22 @@
+@args (RockerContent content)
+@(ruleType)(
+    name = '@name',
+@content
+@for (extraBuckOpt : extraBuckOpts) {
+    @extraBuckOpt,
+}
+@if (!deps.isEmpty()) {
+    deps = [
+    @for (dep : deps) {
+        '@dep',
+    }
+    ],
+}
+@if (!visibility.isEmpty()) {
+    visibility = [
+    @for (v : visibility) {
+        '@v',
+    }
+    ],
+}
+)

--- a/buildSrc/src/main/rocker/template/base/GenRule.rocker.raw
+++ b/buildSrc/src/main/rocker/template/base/GenRule.rocker.raw
@@ -1,0 +1,29 @@
+@import java.util.Collection
+@args (Collection<String> inputs, Collection<String> bashCmds, boolean globSrcs, String output, boolean executable)
+@content => {
+@if (!inputs.isEmpty()) {
+@if (globSrcs) {
+    srcs = glob([
+} else {
+    srcs = [
+}
+    @for (input : inputs) {
+        '@input',
+    }
+@if (globSrcs) {
+    ]),
+} else {
+    ],
+}
+}
+    out = '@output',
+@if (executable) {
+    executable = True,
+}
+    bash = '' \
+@for (bashCmd : bashCmds) {
+    '@bashCmd ' \
+}
+    '',
+}
+@template.base.BuckRule.template(content)

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -18,6 +18,7 @@ def build = [
         mavenArtifact    : 'org.apache.maven:maven-artifact:3.3.9',
         okio             : "com.squareup.okio:okio:1.13.0",
         retrolambdaPlugin: 'me.tatarka:gradle-retrolambda:3.7.0',
+        rockerRuntime    : 'com.fizzed:rocker-runtime:0.22.0',
         sqlDelightPlugin : 'com.squareup.sqldelight:gradle-plugin:0.6.1',
         shadowJar        : "com.github.jengelman.gradle.plugins:shadow:2.0.1",
 ]


### PR DESCRIPTION
Ref #509

This adds support for writing buck rules based on the https://github.com/fizzed/rocker template engine

![Template Comparison](https://raw.githubusercontent.com/fizzed/rocker/master/docs/benchmark.png)

This allows for modifying templates in a more simple way and comes with lot of performance benefits as the templates are now precompiled to java code. This is going to allow incremental execution of okbuck tasks by outputting each rule to an intermediate file for later merging.