### PR TITLE
Remove ',' after alias value in buckconfig template.

### DIFF
--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckConfig.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckConfig.rocker.raw
@@ -13,7 +13,7 @@ Collection defs
 @if (valid(aliases)) {
 [alias]
 @for ((key, val) : aliases) {
-    @key = @val,
+    @key = @val
 }
 }
 @if (valid(buildToolsVersion) && valid(target)) {


### PR DESCRIPTION
Otherwise aliases generated in `.buckconfig.local` don't work :) 