### PR TITLE
Sort deps in generated BUCK files

### DIFF
--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/android/AndroidBinaryRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/android/AndroidBinaryRule.rocker.raw
@@ -36,7 +36,7 @@ boolean multidexEnabled,
     preprocess_java_classes_bash = '@preprocessJavaClassesBash',
 @if (valid(preprocessJavaClassesDeps)) {
     preprocess_java_classes_deps = [
-    @for (preprocessJavaClassesDep : preprocessJavaClassesDeps) {
+    @for (preprocessJavaClassesDep : sorted(preprocessJavaClassesDeps)) {
         '@preprocessJavaClassesDep',
     }
     ],
@@ -44,7 +44,7 @@ boolean multidexEnabled,
 }
 @if (valid(cpuFilters)) {
     cpu_filters = [
-    @for (cpuFilter : cpuFilters) {
+    @for (cpuFilter : sorted(cpuFilters)) {
         '@cpuFilter',
     }
     ],

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/android/AndroidRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/android/AndroidRule.rocker.raw
@@ -47,7 +47,7 @@ env
 }
 @if (valid(exportedDeps)) {
     exported_deps = [
-    @for (exportedDep : exportedDeps) {
+    @for (exportedDep : sorted(exportedDeps)) {
         '@exportedDep',
     }
     ],

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/android/BuildConfigRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/android/BuildConfigRule.rocker.raw
@@ -4,7 +4,7 @@
     package = '@pkg',
 @if (valid(values)) {
     values = [
-    @for (value : values) {
+    @for (value : sorted(values)) {
         '@value',
     }
     ],

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/android/GenAidlRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/android/GenAidlRule.rocker.raw
@@ -9,7 +9,7 @@ okbuck_aidl(
 }
 @if (valid(aidlDeps)) {
     deps = [
-    @for (aidlDep : aidlDeps) {
+    @for (aidlDep : sorted(aidlDeps)) {
         '@aidlDep',
     }
     ],

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/android/LintRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/android/LintRule.rocker.raw
@@ -18,17 +18,17 @@ okbuck_lint(
 }
 @if (valid(sources) || valid(resources)) {
     inputs = [
-    @for (source : sources) {
+    @for (source : sorted(sources)) {
         '@source',
     }
-    @for (resource : resources) {
+    @for (resource : sorted(resources)) {
         '@resource',
     }
     ],
 }
 @if (valid(customLints)) {
     custom_lints = [
-    @for (customLint : customLints) {
+    @for (customLint : sorted(customLints)) {
         '@customLint',
     }
     ],
@@ -38,19 +38,19 @@ okbuck_lint(
 }
 @if (valid(deps)) {
     deps = [
-    @for (dep : deps) {
+    @for (dep : sorted(deps)) {
         '@dep',
     }
     ],
 }
     lint_options = [
 @if (valid(sources)) {
-    @for (source : sources) {
+    @for (source : sorted(sources)) {
         '--sources @source',
     }
 }
 @if (valid(resources)) {
-    @for (resource : resources) {
+    @for (resource : sorted(resources)) {
         '--resources @resource',
     }
 }

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/android/ResourceRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/android/ResourceRule.rocker.raw
@@ -4,14 +4,14 @@
     package = '@pkg',
 @if (valid(res)) {
     res = res_glob([
-    @for (r : res) {
+    @for (r : sorted(res)) {
         ('@r', '**'),
     }
     ]),
 }
 @if (valid(assets)) {
     assets = subdir_glob([
-    @for (a : assets) {
+    @for (a : sorted(assets)) {
         ('@a', '**'),
     }
     ]),

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/base/BuckRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/base/BuckRule.rocker.raw
@@ -8,14 +8,14 @@
 }
 @if (valid(deps)) {
     deps = [
-    @for (dep : deps) {
+    @for (dep : sorted(deps)) {
         '@dep',
     }
     ],
 }
 @if (valid(labels)) {
     labels = [
-    @for (label : labels) {
+    @for (label : sorted(labels)) {
         '@label',
     }
     ],

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/base/GenRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/base/GenRule.rocker.raw
@@ -13,7 +13,7 @@ boolean executable
 } else {
     srcs = [
 }
-    @for (input : inputs) {
+    @for (input : sorted(inputs)) {
         '@input',
     }
 @if (globSrcs) {

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/core/Rule.java
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/core/Rule.java
@@ -3,6 +3,7 @@ package com.uber.okbuck.template.core;
 import com.fizzed.rocker.runtime.DefaultRockerModel;
 import com.fizzed.rocker.runtime.OutputStreamOutput;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -11,6 +12,7 @@ import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
 
 public abstract class Rule<T extends Rule> extends DefaultRockerModel {
 
@@ -85,5 +87,13 @@ public abstract class Rule<T extends Rule> extends DefaultRockerModel {
         } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    protected static Collection<String> sorted(Collection c) {
+        ImmutableSortedSet.Builder<String> builder = new ImmutableSortedSet.Builder<>(String::compareTo);
+        for (Object o : c) {
+            builder.add(o.toString());
+        }
+        return builder.build();
     }
 }

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/java/JavaBinaryRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/java/JavaBinaryRule.rocker.raw
@@ -9,7 +9,7 @@ Set excludes
 }
 @if (excludes != null && !excludes.isEmpty()) {
     blacklist = [
-    @for (exclude : excludes) {
+    @for (exclude : sorted(excludes)) {
         '@exclude',
     }
     ],

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/java/JavaRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/java/JavaRule.rocker.raw
@@ -20,14 +20,14 @@ RockerBody content
 @com.uber.okbuck.template.base.BuckRule.template() -> {
 @if (valid(srcs)) {
     srcs = glob([
-    @for (src : srcs) {
-    @for (ext : exts) {
+    @for (src : sorted(srcs)) {
+    @for (ext : sorted(exts)) {
         '@src/**/*.@ext',
     }
     }
 @if (valid(excludes)) {
     ], excludes = [
-    @for (exclude : excludes) {
+    @for (exclude : sorted(excludes)) {
         '@exclude',
     }
 }
@@ -51,28 +51,28 @@ RockerBody content
 }
 @if (valid(annotationProcessors)) {
     annotation_processors = [
-    @for (annotationProcessor : annotationProcessors) {
+    @for (annotationProcessor : sorted(annotationProcessors)) {
         '@annotationProcessor',
     }
     ],
 }
 @if (valid(aptDeps)) {
     annotation_processor_deps = [
-    @for (aptDep : aptDeps) {
+    @for (aptDep : sorted(aptDeps)) {
         '@aptDep',
     }
     ],
 }
 @if (valid(providedDeps)) {
     provided_deps = [
-    @for (providedDep : providedDeps) {
+    @for (providedDep : sorted(providedDeps)) {
         '@providedDep',
     }
     ],
 }
 @if (valid(options)) {
     extra_arguments = [
-    @for (option : options) {
+    @for (option : sorted(options)) {
         '@option',
     }
     ],
@@ -86,7 +86,7 @@ RockerBody content
 }
 @if (valid(jvmArgs)) {
     vm_args = [
-    @for (jvmArg : jvmArgs) {
+    @for (jvmArg : sorted(jvmArgs)) {
         '@jvmArg',
     }
     ],


### PR DESCRIPTION
The order of deps (i.e classpath) matter for the cache keys of buck. This restores the old behavior of sorting deps entries