### PR TITLE
Remove target validity check in TransformBuckFile.rocker.raw

### DIFF
--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/TransformBuckFile.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/TransformBuckFile.rocker.raw
@@ -24,9 +24,7 @@ for jar in jars:
 
 java_binary(
     name='okbuck_transform',
-@if (valid(targetDeps)) {
     deps=map(lambda x: ":" + x, jars) + [@(String.join(", ", targetDeps))],
-}
     blacklist=[
         'META-INF',
     ],


### PR DESCRIPTION
This check was preventing okbuck_transform.jar from depending on all of the cached jar files. We want to add the jar dependencies regardless of whether targetDeps is valid or not.