### PR TITLE
Pass the merged manifest to Robolectric tests for app modules

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidTestRuleComposer.groovy
@@ -1,6 +1,7 @@
 package com.uber.okbuck.composer.android
 
 import com.google.common.collect.ImmutableSet
+import com.uber.okbuck.core.model.android.AndroidAppTarget
 import com.uber.okbuck.core.model.android.AndroidLibTarget
 import com.uber.okbuck.core.model.base.RuleType
 import com.uber.okbuck.core.util.RetrolambdaUtil
@@ -20,7 +21,8 @@ final class AndroidTestRuleComposer extends AndroidBuckRuleComposer {
             AndroidLibTarget target,
             List<String> deps,
             final List<String> aidlRuleNames,
-            String appClass) {
+            String appClass,
+            String manifestRuleName) {
 
         List<String> testDeps = new ArrayList<>(deps)
         testDeps.add(":${src(target)}")
@@ -55,7 +57,7 @@ final class AndroidTestRuleComposer extends AndroidBuckRuleComposer {
                 .options(target.main.jvmArgs)
                 .jvmArgs(target.testOptions.jvmArgs)
                 .env(target.testOptions.env)
-                .robolectricManifest(fileRule(target.manifest))
+                .robolectricManifest(manifestRuleName != null ? manifestRuleName : fileRule(target.manifest))
                 .runtimeDependency(RobolectricUtil.ROBOLECTRIC_CACHE)
 
         if (target.testRuleType == RuleType.KOTLIN_ROBOLECTRIC_TEST) {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidTestRuleComposer.groovy
@@ -21,8 +21,7 @@ final class AndroidTestRuleComposer extends AndroidBuckRuleComposer {
             AndroidLibTarget target,
             List<String> deps,
             final List<String> aidlRuleNames,
-            String appClass,
-            String manifestRuleName) {
+            String appClass) {
 
         List<String> testDeps = new ArrayList<>(deps)
         testDeps.add(":${src(target)}")
@@ -42,6 +41,8 @@ final class AndroidTestRuleComposer extends AndroidBuckRuleComposer {
             providedDeps.add(RetrolambdaUtil.getRtStubJarRule())
         }
 
+        String manifest = target instanceof AndroidAppTarget ? ":${AndroidBuckRuleComposer.manifest(target)}" : fileRule(target.manifest)
+
         AndroidRule androidRule = new AndroidRule()
                 .srcs(target.test.sources)
                 .exts(target.testRuleType.sourceExtensions)
@@ -57,7 +58,7 @@ final class AndroidTestRuleComposer extends AndroidBuckRuleComposer {
                 .options(target.main.jvmArgs)
                 .jvmArgs(target.testOptions.jvmArgs)
                 .env(target.testOptions.env)
-                .robolectricManifest(manifestRuleName != null ? manifestRuleName : fileRule(target.manifest))
+                .robolectricManifest(manifest)
                 .runtimeDependency(RobolectricUtil.ROBOLECTRIC_CACHE)
 
         if (target.testRuleType == RuleType.KOTLIN_ROBOLECTRIC_TEST) {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
@@ -180,10 +180,7 @@ final class BuckFileGenerator {
 
         // Test
         if (target.robolectric && target.test.sources && !target.isTest) {
-            String manifestRuleName = null
-            if (target instanceof AndroidAppTarget) {
-                manifestRuleName = ":manifest_${target.name}"
-            }
+            String manifestRuleName = target instanceof AndroidAppTarget ? ":${AndroidBuckRuleComposer.manifest(target)}" : null
 
             androidLibRules.add(AndroidTestRuleComposer.compose(
                     target,

--- a/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
@@ -180,14 +180,11 @@ final class BuckFileGenerator {
 
         // Test
         if (target.robolectric && target.test.sources && !target.isTest) {
-            String manifestRuleName = target instanceof AndroidAppTarget ? ":${AndroidBuckRuleComposer.manifest(target)}" : null
-
             androidLibRules.add(AndroidTestRuleComposer.compose(
                     target,
                     deps,
                     aidlRuleNames,
-                    appClass,
-                    manifestRuleName))
+                    appClass))
         }
 
         OkBuckExtension okbuck = target.rootProject.okbuck

--- a/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
@@ -182,9 +182,7 @@ final class BuckFileGenerator {
         if (target.robolectric && target.test.sources && !target.isTest) {
             String manifestRuleName = null
             if (target instanceof AndroidAppTarget) {
-                Rule manifestRule = AndroidManifestRuleComposer.compose(target)
-                rules.add(manifestRule)
-                manifestRuleName = ":${manifestRule.name()}"
+                manifestRuleName = ":manifest_${target.name}"
             }
 
             androidLibRules.add(AndroidTestRuleComposer.compose(

--- a/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
@@ -180,11 +180,19 @@ final class BuckFileGenerator {
 
         // Test
         if (target.robolectric && target.test.sources && !target.isTest) {
+            String manifestRuleName = null
+            if (target instanceof AndroidAppTarget) {
+                Rule manifestRule = AndroidManifestRuleComposer.compose(target)
+                rules.add(manifestRule)
+                manifestRuleName = ":${manifestRule.name()}"
+            }
+
             androidLibRules.add(AndroidTestRuleComposer.compose(
                     target,
                     deps,
                     aidlRuleNames,
-                    appClass))
+                    appClass,
+                    manifestRuleName))
         }
 
         OkBuckExtension okbuck = target.rootProject.okbuck

--- a/libraries/common/src/main/AndroidManifest.xml
+++ b/libraries/common/src/main/AndroidManifest.xml
@@ -6,6 +6,11 @@
         android:label="@string/app_name"
         android:supportsRtl="true">
 
+        <activity
+            android:name="com.uber.okbuck.example.common.AnotherActivity"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme.NoActionBar"/>
+
     </application>
 
 </manifest>

--- a/libraries/common/src/main/java/com/uber/okbuck/example/common/AnotherActivity.java
+++ b/libraries/common/src/main/java/com/uber/okbuck/example/common/AnotherActivity.java
@@ -1,0 +1,14 @@
+package com.uber.okbuck.example.common;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.widget.FrameLayout;
+
+public class AnotherActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(new FrameLayout(this));
+    }
+}


### PR DESCRIPTION
This is useful to be able to write tests that catch all activities or permissions that run only once per app. This passes the merged Android manifest for app modules but not for library modules.