### PR TITLE
Add support for Lint 26.0.0-beta7

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/LintRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/LintRuleComposer.groovy
@@ -28,15 +28,14 @@ final class LintRuleComposer extends JvmBuckRuleComposer {
 
         List<String> customLintRules = []
         customLintRules.addAll(external(target.main.packagedLintJars))
-        customLintRules.addAll(targets(customLintTargets as Set))
+        customLintTargets.each {
+            if (it instanceof JavaLibTarget && it.hasApplication()) {
+                customLintRules.add(binTargets(it))
+            }
+        }
 
         List<String> lintDeps = []
         lintDeps.addAll(LintUtil.LINT_DEPS_RULE)
-        customLintTargets.each {
-            if (it instanceof JavaLibTarget && it.hasApplication()) {
-                lintDeps.add(binTargets(it))
-            }
-        }
 
         LintExtension lintExtension = target.rootProject.okbuck.lint
         return new LintRule()

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 def versions = [
-        androidTools         : '26.0.0-alpha9',
+        androidTools         : '26.0.0-beta7',
         butterKnifeVersion   : '8.6.0',
         daggerVersion        : '2.11',
         kotlinVersion        : '1.1.50',

--- a/libraries/customLintLibrary/build.gradle
+++ b/libraries/customLintLibrary/build.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-    compile deps.lint.lintApi
-    compile deps.lint.lintChecks
+    compileOnly deps.lint.lintApi
+    compileOnly deps.lint.lintChecks
 
     testCompile deps.lint.lint
     testCompile deps.lint.lintTests


### PR DESCRIPTION
Updates custom lint check module to have lint and lint-api as compileOnly and moves custom lint jars from primary to secondary classpath after [this discussion](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/lint-dev/J6XVMjGM8Hs/vAaK2LXYAAAJ). The primary will now only contain the okbuck_lint fat jar while the secondary classpath will have third party lint checks like timber plus the bin_main targets of custom lint check modules.

Addresses #529