### PR TITLE
Fix OkBuck exception when buildscript dependency is Jar

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
@@ -1,5 +1,8 @@
 package com.uber.okbuck.core.util;
 
+import java.io.File;
+import java.util.Map;
+
 import com.android.build.gradle.AppPlugin;
 import com.android.build.gradle.LibraryPlugin;
 import com.uber.okbuck.OkBuckGradlePlugin;
@@ -8,7 +11,6 @@ import com.uber.okbuck.core.model.base.ProjectType;
 import com.uber.okbuck.core.model.base.Scope;
 import com.uber.okbuck.core.model.base.Target;
 import com.uber.okbuck.core.model.base.TargetCache;
-
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.plugins.GroovyPlugin;
@@ -17,9 +19,6 @@ import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.plugins.scala.ScalaPlugin;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper;
-
-import java.io.File;
-import java.util.Map;
 
 public final class ProjectUtil {
 
@@ -78,14 +77,13 @@ public final class ProjectUtil {
                 .getArtifacts()
                 .getArtifacts()
                 .stream()
-                .filter(resolvedArtifactResult -> {
-                    ModuleComponentIdentifier identifier =
-                            (ModuleComponentIdentifier) resolvedArtifactResult.getId().getComponentIdentifier();
-                    return (group.equals(identifier.getGroup()) &&
-                            module.equals(identifier.getModule()));
-                })
+                .map(artifactResult -> artifactResult.getId().getComponentIdentifier())
+                .filter(identifier -> identifier instanceof ModuleComponentIdentifier)
+                .map(componentIdentifier -> (ModuleComponentIdentifier) componentIdentifier)
+                .filter(identifier -> (group.equals(identifier.getGroup()) &&
+                        module.equals(identifier.getModule())))
                 .findFirst()
-                .map(r -> ((ModuleComponentIdentifier) r.getId().getComponentIdentifier()).getVersion())
+                .map(ModuleComponentIdentifier::getVersion)
                 .orElse(null);
     }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
@@ -2,6 +2,7 @@ package com.uber.okbuck.core.util;
 
 import java.io.File;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import com.android.build.gradle.AppPlugin;
 import com.android.build.gradle.LibraryPlugin;
@@ -77,9 +78,10 @@ public final class ProjectUtil {
                 .getArtifacts()
                 .getArtifacts()
                 .stream()
-                .map(artifactResult -> artifactResult.getId().getComponentIdentifier())
-                .filter(identifier -> identifier instanceof ModuleComponentIdentifier)
-                .map(componentIdentifier -> (ModuleComponentIdentifier) componentIdentifier)
+                .flatMap(artifactResult ->
+                    artifactResult.getId().getComponentIdentifier() instanceof ModuleComponentIdentifier
+                        ? Stream.of((ModuleComponentIdentifier) artifactResult.getId().getComponentIdentifier())
+                        : Stream.empty())
                 .filter(identifier -> (group.equals(identifier.getGroup()) &&
                         module.equals(identifier.getModule())))
                 .findFirst()


### PR DESCRIPTION
When using Gradle buildscript dependencies as jar files, OkBuck would throw a 
```
Caused by: java.lang.ClassCastException: org.gradle.internal.component.local.model.OpaqueComponentArtifactIdentifier cannot be cast to org.gradle.api.artifacts.component.ModuleComponentIdentifier
        at com.uber.okbuck.core.util.ProjectUtil.lambda$findVersionInClasspath$0(ProjectUtil.java:83)
        at com.uber.okbuck.core.util.ProjectUtil.findVersionInClasspath(ProjectUtil.java:87)
        at com.uber.okbuck.core.util.LintUtil.getDefaultLintVersion(LintUtil.java:31)
        at com.uber.okbuck.extension.LintExtension.<init>(LintExtension.java:28)
        at com.uber.okbuck.extension.LintExtension_Decorated.<init>(Unknown Source)
        at org.gradle.internal.reflect.DirectInstantiator.newInstance(DirectInstantiator.java:51)
        ... 134 more
```

This fixes it by filtering the stream to only `ComponentIdentifier` instances that are `ModuleComponentIdentifier`.

Example test case:
```
buildscript {
  dependencies {
    classpath files("libs/foobar.jar")
  }
}
```

It wasn't obvious where to write a test for this, but I'd be happy to write one if you could provide pointers.