### PR TITLE
Do not use merged manifest for lint and unit tests

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidLibraryRuleComposer.groovy
@@ -18,7 +18,6 @@ final class AndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
     static Rule compose(
             AndroidLibTarget target,
             List<String> deps,
-            String manifestRuleName,
             final List<String> aidlRuleNames,
             String appClass) {
         List<String> libraryDeps = new ArrayList<>(deps)
@@ -52,7 +51,7 @@ final class AndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
         AndroidRule androidRule = new AndroidRule()
                 .srcs(target.main.sources)
                 .exts(target.ruleType.sourceExtensions)
-                .manifest(manifestRuleName)
+                .manifest(fileRule(target.manifest))
                 .annotationProcessors(target.annotationProcessors)
                 .aptDeps(libraryAptDeps)
                 .providedDeps(providedDeps)

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidTestRuleComposer.groovy
@@ -19,7 +19,6 @@ final class AndroidTestRuleComposer extends AndroidBuckRuleComposer {
     static Rule compose(
             AndroidLibTarget target,
             List<String> deps,
-            String manifestRuleName,
             final List<String> aidlRuleNames,
             String appClass) {
 
@@ -56,7 +55,7 @@ final class AndroidTestRuleComposer extends AndroidBuckRuleComposer {
                 .options(target.main.jvmArgs)
                 .jvmArgs(target.testOptions.jvmArgs)
                 .env(target.testOptions.env)
-                .robolectricManifest(manifestRuleName)
+                .robolectricManifest(fileRule(target.manifest))
                 .runtimeDependency(RobolectricUtil.ROBOLECTRIC_CACHE)
 
         if (target.testRuleType == RuleType.KOTLIN_ROBOLECTRIC_TEST) {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/LintRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/LintRuleComposer.groovy
@@ -38,7 +38,7 @@ final class LintRuleComposer extends AndroidBuckRuleComposer {
 
         LintExtension lintExtension = target.rootProject.okbuck.lint
         return new LintRule()
-                .manifest(":${manifest(target)}")
+                .manifest(fileRule(target.manifest))
                 .sources(target.main.sources)
                 .resources(target.resDirs)
                 .customLints(customLintRules)

--- a/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
@@ -155,9 +155,6 @@ final class BuckFileGenerator {
         // Res
         androidLibRules.add(AndroidResourceRuleComposer.compose(target))
 
-        Rule manifestRule = AndroidManifestRuleComposer.compose(target)
-        rules.add(manifestRule)
-
         // BuildConfig
         androidLibRules.add(AndroidBuildConfigRuleComposer.compose(target))
 
@@ -175,7 +172,6 @@ final class BuckFileGenerator {
         androidLibRules.add(AndroidLibraryRuleComposer.compose(
                 target,
                 deps,
-                ":${manifestRule.name()}",
                 aidlRuleNames,
                 appClass
         ))
@@ -185,7 +181,6 @@ final class BuckFileGenerator {
             androidLibRules.add(AndroidTestRuleComposer.compose(
                     target,
                     deps,
-                    ":${manifestRule.name()}",
                     aidlRuleNames,
                     appClass))
         }


### PR DESCRIPTION
Looking at the source of the android gradle plugin, it seems like the merged manifest is not used for lint or for running unit tests. Mimic'ing the same behavior