### PR TITLE
Add option to disable generating build config rules for library modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,6 +186,7 @@ okbuck {
     }
 
     extraDefs += project.file('tooling/buck-defs/DEFS')
+    libraryBuildConfig = false
 }
 
 gradle.buildFinished {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidAppTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidAppTarget.groovy
@@ -83,6 +83,12 @@ class AndroidAppTarget extends AndroidLibTarget {
     }
 
     @Override
+    boolean shouldGenerateBuildConfig() {
+        // Always generate for apps
+        return true
+    }
+
+    @Override
     String processManifestXml(GPathResult manifestXml) {
         if (isTest) {
             manifestXml.@package = applicationId + applicationIdSuffix + ".test"

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidLibTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidLibTarget.groovy
@@ -27,6 +27,10 @@ class AndroidLibTarget extends AndroidTarget {
         return ManifestMerger2.MergeType.LIBRARY
     }
 
+    boolean shouldGenerateBuildConfig() {
+        return okbuck.libraryBuildConfig
+    }
+
     List<String> getKotlincArguments() {
         if (!hasKotlinAndroidExtensions) {
             return ImmutableList.of()

--- a/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/generator/BuckFileGenerator.groovy
@@ -155,7 +155,9 @@ final class BuckFileGenerator {
         androidLibRules.add(AndroidResourceRuleComposer.compose(target))
 
         // BuildConfig
-        androidLibRules.add(AndroidBuildConfigRuleComposer.compose(target))
+        if (target.shouldGenerateBuildConfig()) {
+            androidLibRules.add(AndroidBuildConfigRuleComposer.compose(target))
+        }
 
         // Jni
         androidLibRules.addAll(target.jniLibs.collect { String jniLib ->

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
@@ -99,6 +99,12 @@ public class OkBuckExtension {
     public boolean resourceUnion = true;
 
     /**
+     * Whether to generate android_build_config rules for library projects
+     */
+    @Input
+    public boolean libraryBuildConfig = true;
+
+    /**
      * List of exclude patterns for resources to be processed by aapt
      */
     @Input

--- a/dummylibrary/build.gradle
+++ b/dummylibrary/build.gradle
@@ -2,10 +2,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'me.tatarka.retrolambda'
 
 android {
-    defaultConfig {
-        buildConfigField "String", "DUMMY_CONFIG", "\"default\""
-    }
-
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
@@ -19,12 +15,8 @@ android {
 
     publishNonDefault true
     productFlavors {
-        free {
-            buildConfigField "String", "DUMMY_CONFIG", "\"free\""
-        }
-        paid {
-            buildConfigField "String", "DUMMY_CONFIG", "\"paid\""
-        }
+        free {}
+        paid {}
     }
 }
 

--- a/dummylibrary/src/com/uber/okbuck/example/dummylibrary/DummyAndroidClass.java
+++ b/dummylibrary/src/com/uber/okbuck/example/dummylibrary/DummyAndroidClass.java
@@ -7,7 +7,7 @@ import com.google.gson.GsonBuilder;
 
 public class DummyAndroidClass {
     public String getAndroidWord(Context context) {
-        Toast.makeText(context, "getAndroidWord: " + BuildConfig.DUMMY_CONFIG, Toast.LENGTH_SHORT).show();
+        Toast.makeText(context, "getAndroidWord: Dummy", Toast.LENGTH_SHORT).show();
         String mock = "{\"lang\":\"" + context.getString(R.string.dummy_library_android_str) + "\"}";
         return new GsonBuilder().create().fromJson(mock, DummyObject.class).lang;
     }

--- a/libraries/common/build.gradle
+++ b/libraries/common/build.gradle
@@ -8,12 +8,8 @@ android {
 
     publishNonDefault true
     productFlavors {
-        free {
-            buildConfigField "String", "COMMON_CONFIG", "\"free\""
-        }
-        paid {
-            buildConfigField "String", "COMMON_CONFIG", "\"paid\""
-        }
+        free {}
+        paid {}
     }
 }
 

--- a/libraries/common/src/main/java/com/uber/okbuck/example/common/Calc.java
+++ b/libraries/common/src/main/java/com/uber/okbuck/example/common/Calc.java
@@ -10,7 +10,7 @@ public class Calc {
     }
 
     public int add(int a, int b) {
-        mCalcMonitor.addCalled(BuildConfig.COMMON_CONFIG);
+        mCalcMonitor.addCalled("flavor");
         return a + b;
     }
 }


### PR DESCRIPTION
Library build configs are typically not useful as apps tend to override things like version/debug mode etc. This adds an option to turn off library build configs entirely to save time during builds