### PR TITLE
Use relative paths for lint runs.

### DIFF
--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/android/LintRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/android/LintRule.rocker.raw
@@ -46,12 +46,12 @@ okbuck_lint(
     lint_options = [
 @if (valid(sources)) {
     @for (source : sorted(sources)) {
-        '--sources {}/@source'.format(get_base_path()),
+        '--sources @source',
     }
 }
 @if (valid(resources)) {
     @for (resource : sorted(resources)) {
-        '--resources {}/@resource'.format(get_base_path()),
+        '--resources @resource',
     }
 }
 @if (lintOptions.isAbortOnError()) {


### PR DESCRIPTION
Looking at this commit:
https://github.com/uber/okbuck/commit/cd6c24f7eb8ad2bef87b46e1ba2b92bcf6327dd9

Current template creates rules like this:
lint_options = [
    '--sources {}/src/main/java'.format(get_base_path()),
    '--resources {}/src/main/res'.format(get_base_path()),
    '--exitcode',
    '--config $(location //.okbuck/cache/lint:config_lint_lint.xml)',
    '--xml "$OUT/lint-results.xml"',
    '--html "$OUT/lint-results.html"',
]

This can create errant paths like the ones bellow:

```
<issue
    id="MissingSuperCall"
    severity="Error"
    message="Overriding method should call `super.onCreate`"
    category="Correctness"
    priority="9"
    summary="Missing Super Call"
    explanation="Some methods, such as `View#onDetachedFromWindow`, require that you also call the super&#xA;implementation as part of your method."
    errorLine1="  protected void onCreate(Bundle savedInstanceState) {"
    errorLine2="                 ~~~~~~~~">
    <location
        file="../../../../../../../<base_path>/src/main/java/Activity.java"
        line="27"
        column="18"/>
</issue>
```

This commit updates the lint_options back to, tested this against known happy and sad cases within internal repo:
lint_options = [
        '--sources src/main/java',
        '--resources src/main/res',
        '--exitcode',
        '--config $(location //.okbuck/cache/lint:config_lint_lint.xml)',
        '--xml "$OUT/lint-results.xml"',
        '--html "$OUT/lint-results.html"',
]

```
<issue
    id="MissingSuperCall"
    severity="Error"
    message="Overriding method should call `super.onCreate`"
    category="Correctness"
    priority="9"
    summary="Missing Super Call"
    explanation="Some methods, such as `View#onDetachedFromWindow`, require that you also call the super&#xA;implementation as part of your method."
    errorLine1="  protected void onCreate(Bundle savedInstanceState) {"
    errorLine2="                 ~~~~~~~~">
    <location
        file="src/main/java/com/Activity.java"
        line="27"
        column="18"/>
</issue>
```