### PR TITLE
Switch to using inbuilt consumer proguard file support in buck

### DIFF
--- a/another-app/build.gradle
+++ b/another-app/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     compile deps.support.v4
     compile project(":libraries:javalibrary")
     compile project(":libraries:emptylibrary")
+    compile project(":libraries:parcelable")
     releaseCompile project(path: ':libraries:common', configuration: 'paidRelease')
     debugCompile project(path: ':libraries:common', configuration: 'freeDebug')
 }

--- a/another-app/proguard-android.txt
+++ b/another-app/proguard-android.txt
@@ -95,3 +95,5 @@
 -keepclasseswithmembers class * {
     @android.support.annotation.Keep <init>(...);
 }
+
+-dontwarn java.lang.invoke.**

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/android/AndroidLibraryRuleComposer.groovy
@@ -49,6 +49,7 @@ final class AndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
                 .srcs(target.main.sources)
                 .exts(target.ruleType.sourceExtensions)
                 .manifest(fileRule(target.manifest))
+                .proguardConfig(target.consumerProguardConfig)
                 .annotationProcessors(target.annotationProcessors)
                 .aptDeps(libraryAptDeps)
                 .providedDeps(providedDeps)

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/DependencyCache.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/DependencyCache.groovy
@@ -34,7 +34,6 @@ class DependencyCache {
     private final boolean fetchSources
     private final Store lintJars
     private final Store processors
-    private final Store proguardConfigs
     private final Store sources
 
     private final Set<File> copies = ConcurrentHashMap.newKeySet()
@@ -50,7 +49,6 @@ class DependencyCache {
         sources = new Store(rootProject.file("${OkBuckGradlePlugin.OKBUCK_STATE_DIR}/SOURCES"))
         processors = new Store(rootProject.file("${OkBuckGradlePlugin.OKBUCK_STATE_DIR}/PROCESSORS"))
         lintJars = new Store(rootProject.file("${OkBuckGradlePlugin.OKBUCK_STATE_DIR}/LINT_JARS"))
-        proguardConfigs = new Store(rootProject.file("${OkBuckGradlePlugin.OKBUCK_STATE_DIR}/PROGUARD_CONFIGS"))
 
         if (forcedConfiguration) {
             Scope.from(project, Collections.singleton(forcedConfiguration)).external.each {
@@ -65,7 +63,6 @@ class DependencyCache {
         sources.persist()
         processors.persist()
         lintJars.persist()
-        proguardConfigs.persist()
         cleanup()
     }
 
@@ -209,22 +206,6 @@ class DependencyCache {
     String getLintJar(ExternalDependency externalDependency) {
         ExternalDependency dependency = forcedDeps.getOrDefault(externalDependency.versionless, externalDependency)
         return getAarEntry(dependency, lintJars, "lint.jar", "-lint.jar")
-    }
-
-    /**
-     * Get the packaged proguard config of an aar dependency if any.
-     *
-     * @param externalDependency The depenency
-     * @return path to the proguard config in the cache.
-     */
-    File getProguardConfig(ExternalDependency externalDependency) {
-        ExternalDependency dependency = forcedDeps.getOrDefault(externalDependency.versionless, externalDependency)
-        String entry = getAarEntry(dependency, proguardConfigs, "proguard.txt", "-proguard.pro")
-        if (entry) {
-            return rootProject.file(entry)
-        } else {
-            return null
-        }
     }
 
     void build(Configuration configuration, boolean cleanupDeps = true, boolean useFullDepname = false) {

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidLibTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/android/AndroidLibTarget.groovy
@@ -3,6 +3,7 @@ package com.uber.okbuck.core.model.android
 import com.android.build.gradle.api.BaseVariant
 import com.android.manifmerger.ManifestMerger2
 import com.google.common.collect.ImmutableList
+import com.uber.okbuck.core.util.FileUtil
 import com.uber.okbuck.core.util.KotlinUtil
 import org.gradle.api.Project
 
@@ -31,12 +32,21 @@ class AndroidLibTarget extends AndroidTarget {
         return okbuck.libraryBuildConfig
     }
 
+    String getConsumerProguardConfig() {
+        Set<File> consumerProguardFiles = (baseVariant.mergedFlavor.consumerProguardFiles +
+                baseVariant.buildType.consumerProguardFiles)
+        if (consumerProguardFiles.size() > 0 && consumerProguardFiles[0].exists()) {
+            return FileUtil.getRelativePath(project.projectDir, consumerProguardFiles[0])
+        }
+        return null
+    }
+
     List<String> getKotlincArguments() {
         if (!hasKotlinAndroidExtensions) {
             return ImmutableList.of()
         }
 
-        ImmutableList.Builder<String> extraKotlincArgs = ImmutableList.<String>builder()
+        ImmutableList.Builder<String> extraKotlincArgs = ImmutableList.<String> builder()
         StringBuilder plugin = new StringBuilder()
         StringBuilder resDirs = new StringBuilder()
         StringBuilder options = new StringBuilder()

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/android/AndroidRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/android/AndroidRule.rocker.raw
@@ -7,6 +7,7 @@ Collection excludes,
 String sourceCompatibility,
 String targetCompatibility,
 String resourcesDir,
+String proguardConfig,
 Collection testTargets,
 Collection annotationProcessors,
 Collection aptDeps,
@@ -54,6 +55,9 @@ env
 }
 @if (generateR2) {
     final_r_name = 'R2',
+}
+@if (valid(proguardConfig)) {
+    proguard_config = '@proguardConfig',
 }
 @if (valid(runtimeDependency)) {
     force_final_resource_ids = False,

--- a/libraries/parcelable/build.gradle
+++ b/libraries/parcelable/build.gradle
@@ -1,1 +1,7 @@
 apply plugin: 'com.android.library'
+
+android {
+	defaultConfig {
+		consumerProguardFiles 'proguard.txt'
+	}
+}

--- a/libraries/parcelable/proguard.txt
+++ b/libraries/parcelable/proguard.txt
@@ -1,0 +1,1 @@
+-keep class com.uber.okbuck.example.common.Person { *; }


### PR DESCRIPTION
We do not need to merge proguard files from aars because buck supports this natively already

Built test app with consumer proguard rules and observed that the keep rules were respected via classy shark

<img width="808" alt="screen shot 2017-11-16 at 3 57 35 pm" src="https://user-images.githubusercontent.com/291148/32922510-61194306-cae7-11e7-914d-8ad647c342db.png">
