### PR TITLE
Always use export_file in reference mode in okbuck

### DIFF
--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/gen/BUCK_FILE
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/gen/BUCK_FILE
@@ -1,6 +1,7 @@
 for file in glob(['AndroidManifest.xml', 'proguard.pro', 'proguard.map']):
   export_file(
     name = file,
+    mode = 'reference',
     visibility = ['PUBLIC'],
   )
 

--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/lint/BUCK_FILE
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/lint/BUCK_FILE
@@ -16,6 +16,7 @@ for xml in glob(['*.xml']):
 for xml in xmls:
   export_file(
     name = xml,
+    mode = 'reference',
     visibility = ['PUBLIC'],
   )
 

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/TransformBuckFile.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/TransformBuckFile.rocker.raw
@@ -12,6 +12,7 @@ for entry in glob(['*.*']):
 for config in configs:
     export_file(
         name = config,
+        mode = 'reference',
         visibility = ['PUBLIC'],
     )
 


### PR DESCRIPTION
- This works around the behavior change in https://github.com/facebook/buck/issues/1630
- Okbuck also does not need a strict copy anywhere it uses `export_file` so this is lot better for build performance in general