### PR TITLE
Use d8 dexer for instrumentation apk.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 
 script:
   - SKIP_OKBUCK= ./buckw --version
-  - ./buckw targets --type android_binary java_test groovy_test robolectric_test kotlin_test scala_test | xargs ./buckw build -v 0
+  - ./buckw targets --type android_binary android_instrumentation_apk java_test groovy_test robolectric_test kotlin_test scala_test | xargs ./buckw build -v 0
   - ./buckw targets --type genrule | grep -v lintErrorLibrary | xargs ./buckw build -v 0
   - ./buckw build //libraries/lintErrorLibrary:lint_debug -v 0;
     if [ $? -eq 0 ]; then

--- a/app/src/androidTest/java/com/uber/okbuck/example/test/MainActivityTest.java
+++ b/app/src/androidTest/java/com/uber/okbuck/example/test/MainActivityTest.java
@@ -10,10 +10,12 @@ import org.junit.runner.RunWith;
 
 import com.uber.okbuck.example.R;
 import android.support.test.runner.AndroidJUnit4;
+
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static junit.framework.Assert.assertEquals;
 
 @RunWith(AndroidJUnit4.class)
 public class MainActivityTest {
@@ -25,5 +27,11 @@ public class MainActivityTest {
     @Test
     public void checkTextDisplayed() {
         onView(withId(R.id.mTextView2)).check(matches(withText("test in app")));
+    }
+
+    @Test
+    public void java8LambdaCompilesAndWorksInInstrumentationApk() {
+        Runnable runnable = () -> assertEquals(3, 2 + 1);
+        runnable.run();
     }
 }

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/android/InstrumentationApkRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/android/InstrumentationApkRule.rocker.raw
@@ -1,5 +1,6 @@
 @args (String manifest, String mainApkRuleName)
 @com.uber.okbuck.template.base.BuckRule.template() -> {
     manifest = '@manifest',
+    dex_tool = 'd8',
     apk = ':@mainApkRuleName',
 }


### PR DESCRIPTION
PR #551 didn't enable d8 dexer for instrumentation apk which causes instrumentation apk build failure if user uses Java 8 lang features.