### PR TITLE
Only use apt configuration for java project annotation processors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     }
     dependencies {
         classpath deps.build.androidPlugin
+        classpath deps.build.aptPlugin
         classpath deps.build.butterKnifePlugin
         classpath deps.build.kotlinPlugin
         classpath deps.build.sqlDelightPlugin

--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/java/JavaTarget.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/java/JavaTarget.groovy
@@ -14,8 +14,8 @@ abstract class JavaTarget extends JvmTarget {
     protected static final String TEST_PREFIX = "test"
 
     private static final Set<String> JAVA_COMPILE_CONFIGS = ["compile"]
-    private static final Set<String> JAVA_APT_CONFIGS = ["apt", "compileOnly"]
-    public static final Set<String> JAVA_PROVIDED_CONFIGS = ["provided", "compileOnly"]
+    private static final Set<String> JAVA_APT_CONFIGS = ["apt"]
+    public static final Set<String> JAVA_PROVIDED_CONFIGS = ["compileOnly", "provided"]
 
     JavaTarget(Project project, String name) {
         super(project, name)

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,6 +11,7 @@ def versions = [
 def build = [
         androidPlugin    : "com.android.tools.build:gradle:${versions.androidPluginVersion}",
         androidPluginApi : "com.android.tools.build:gradle-api:${versions.androidPluginVersion}",
+        aptPlugin        : "net.ltgt.gradle:gradle-apt-plugin:0.13",
         butterKnifePlugin: "com.jakewharton:butterknife-gradle-plugin:${versions.butterKnifeVersion}",
         commonsIo        : 'commons-io:commons-io:2.5',
         commonsLang      : 'commons-lang:commons-lang:2.6',

--- a/libraries/javalibrary/build.gradle
+++ b/libraries/javalibrary/build.gradle
@@ -1,11 +1,12 @@
 apply plugin: 'java'
+apply plugin: "net.ltgt.apt"
 
 dependencies {
     compile deps.external.gson
     compile deps.external.dagger
 
-    compileOnly deps.apt.javax
-    compileOnly deps.apt.daggerCompiler
+    apt deps.apt.javax
+    apt deps.apt.daggerCompiler
 
     testCompile deps.test.junit
 }


### PR DESCRIPTION
Before this change, okbuck would pickup APs from the `compileOnly` configuration only that can cause processor dependencies to pollute the classpath of java projects (unlike android projects that separate the `provided` and `annotationProcessor` configurations). This would cause discrepancies in the buck and gradle builds.

This changes the behavior of okbuck to only pickup processors from the `apt`/`testApt` configurations for java projects. Android project behavior is unchanged.

You may use plugins like https://github.com/tbroyer/gradle-apt-plugin to easily gain access to the `apt` configurations for java projects.