### PR TITLE
Add dependency to repro d8 desugaring failure

### DIFF
--- a/another-app/build.gradle
+++ b/another-app/build.gradle
@@ -33,6 +33,7 @@ android {
 dependencies {
     compile deps.support.appCompat
     compile deps.support.v4
+    compile deps.external.jacksonDatabind
     compile project(":libraries:javalibrary")
     compile project(":libraries:emptylibrary")
     compile project(":libraries:parcelable")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -50,6 +50,7 @@ def external = [
         rxPermissions  : 'com.tbruyelle.rxpermissions2:rxpermissions:0.9.4',
         sqlite         : 'com.pushtorefresh.storio:sqlite:1.13.0',
         xlogAndroidIdle: 'com.github.promeg:xlog-android-idle:2.1.1',
+        jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.9.2',
 ]
 
 def lint = [


### PR DESCRIPTION
Something in the jackson databind jar is causing failures when going through d8's desugaring. I'm adding this here for an easy repro. You can reproduce the failure by running `./buckw build //another-app:bin_debug` on this branch.

The failure is:
```
Buck encountered an internal error
com.android.tools.r8.errors.CompilationError: Class or interface java.lang.Exception required for desugaring of try-with-resources is not found.
	at com.android.tools.r8.ir.optimize.CodeRewriter.isSubtypeOfThrowable(CodeRewriter.java:1845)
	at com.android.tools.r8.ir.optimize.CodeRewriter.matchesMethodOfThrowable(CodeRewriter.java:1835)
	at com.android.tools.r8.ir.optimize.CodeRewriter.rewriteThrowableAddAndGetSuppressed(CodeRewriter.java:1798)
	at com.android.tools.r8.ir.conversion.IRConverter.rewriteCode(IRConverter.java:548)
	at com.android.tools.r8.ir.conversion.IRConverter.convertMethodToDex(IRConverter.java:298)
	at com.android.tools.r8.graph.DexClass.forEachMethodThrowing(DexClass.java:117)
	at com.android.tools.r8.ir.conversion.IRConverter.lambda$convertClassesToDex$2(IRConverter.java:285)
	at java.util.concurrent.ForkJoinTask$AdaptedCallable.exec(ForkJoinTask.java:1424)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
	Suppressed: java.util.concurrent.ExecutionException: com.android.tools.r8.errors.CompilationError: Class or interface java.lang.Exception required for desugaring of try-with-resources is not found.
		at java.util.concurrent.ForkJoinTask.get(ForkJoinTask.java:1006)
		at com.android.tools.r8.utils.ThreadUtils.awaitFutures(ThreadUtils.java:19)
		at com.android.tools.r8.ir.conversion.IRConverter.convertClassesToDex(IRConverter.java:289)
		at com.android.tools.r8.ir.conversion.IRConverter.convertToDex(IRConverter.java:203)
		at com.android.tools.r8.D8.optimize(D8.java:205)
		at com.android.tools.r8.D8.runForTesting(D8.java:176)
		at com.android.tools.r8.D8.runForTesting(D8.java:147)
		at com.android.tools.r8.D8.run(D8.java:70)
		at com.facebook.buck.android.DxStep.executeInProcess(DxStep.java:274)
		at com.facebook.buck.android.DxStep.execute(DxStep.java:236)
		at com.facebook.buck.step.DefaultStepRunner.runStepForBuildTarget(DefaultStepRunner.java:45)
		at com.facebook.buck.rules.CachingBuildRuleBuilder$BuildRuleSteps.executeCommandsNowThatDepsAreBuilt(CachingBuildRuleBuilder.java:1751)
		at com.facebook.buck.rules.CachingBuildRuleBuilder$BuildRuleSteps.run(CachingBuildRuleBuilder.java:1704)
		at com.facebook.buck.util.concurrent.WeightedListeningExecutorService.lambda$2(WeightedListeningExecutorService.java:104)
		at com.facebook.buck.util.concurrent.WeightedListeningExecutorService.lambda$0(WeightedListeningExecutorService.java:78)
		at com.google.common.util.concurrent.AbstractTransformFuture$AsyncTransformFuture.doTransform(AbstractTransformFuture.java:206)
		at com.google.common.util.concurrent.AbstractTransformFuture$AsyncTransformFuture.doTransform(AbstractTransformFuture.java:195)
		at com.google.common.util.concurrent.AbstractTransformFuture.run(AbstractTransformFuture.java:115)
		at com.google.common.util.concurrent.MoreExecutors$5$1.run(MoreExecutors.java:999)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
		at java.lang.Thread.run(Thread.java:745)
	[CIRCULAR REFERENCE:com.android.tools.r8.errors.CompilationError: Class or interface java.lang.Exception required for desugaring of try-with-resources is not found.]

    When running <d8>.
    When building rule //.okbuck/cache:com.fasterxml.jackson.core.jackson-databind-2.9.2.jar#d8.
```

@kageiit let me know if you want more info