### PR TITLE
Make changing versions dependency check less aggressive

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/DependencyCache.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/dependency/DependencyCache.groovy
@@ -70,7 +70,7 @@ class DependencyCache {
     void cleanup() {
         String changingDeps = requested.findAll { ExternalDependency dependency ->
             String version = dependency.version.toString()
-            return version.contains("+") || version.contains("-SNAPSHOT")
+            return version.endsWith("+") || version.endsWith("-SNAPSHOT")
         }.collect { ExternalDependency dependency ->
             dependency.cacheName
         }.join("\n")


### PR DESCRIPTION
Changing versions like `+` or `SNAPSHOT` are always at the end of the version string. This makes the version check less agressive

Fixes #576