### PR TITLE
Fix watchman config default ignores.

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -4,9 +4,8 @@
         ".buckd",
         ".idea",
         "build",
-        ".okbuck/gen",
         ".gradle",
-        ".swp",
+        ".swp"
     ],
     "fsevents_latency": 0.05,
     "suppress_recrawl_warnings": true

--- a/buildSrc/src/main/resources/com/uber/okbuck/core/util/wrapper/WATCHMAN_CONFIG
+++ b/buildSrc/src/main/resources/com/uber/okbuck/core/util/wrapper/WATCHMAN_CONFIG
@@ -5,7 +5,7 @@
         ".idea",
         "build",
         ".gradle",
-        ".swp",
+        ".swp"
     ],
     "fsevents_latency": 0.05,
     "suppress_recrawl_warnings": true


### PR DESCRIPTION
The comma at the end was causing watchman to silently ignore the config.