### PR TITLE
Fix buckBinary configuration name: _ to CamelCase.

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
@@ -63,7 +63,8 @@ class OkBuckGradlePlugin implements Plugin<Project> {
     public static final String TRANSFORM = "transform"
     public static final String SCALA = "scala"
     public static final String FORCED_OKBUCK = "forcedOkbuck"
-    public static final String BUCK_BINARY = "buckBinary"
+    public static final String BUCK_BINARY = "buck_binary"
+    public static final String BUCK_BINARY_CONFIGURATION = "buckBinary"
     public static final String OKBUCK_DEFS = ".okbuck/defs/DEFS"
 
     public static final String OKBUCK_STATE_DIR = ".okbuck/state"
@@ -93,7 +94,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
         // Create configurations
         project.configurations.maybeCreate(TransformUtil.CONFIGURATION_TRANSFORM)
         project.configurations.maybeCreate(FORCED_OKBUCK)
-        Configuration buckBinaryConfiguration = project.configurations.maybeCreate(BUCK_BINARY)
+        Configuration buckBinaryConfiguration = project.configurations.maybeCreate(BUCK_BINARY_CONFIGURATION)
 
         // Create tasks
         Task setupOkbuck = project.task('setupOkbuck')
@@ -130,7 +131,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
                     maven { url JITPACK_URL }
                 }
                 project.dependencies {
-                    delegate."${BUCK_BINARY}" okbuckExt.buckBinary
+                    delegate."${BUCK_BINARY_CONFIGURATION}" okbuckExt.buckBinary
                 }
             }
 

--- a/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
@@ -63,7 +63,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
     public static final String TRANSFORM = "transform"
     public static final String SCALA = "scala"
     public static final String FORCED_OKBUCK = "forcedOkbuck"
-    public static final String BUCK_BINARY = "buck_binary"
+    public static final String BUCK_BINARY = "buckBinary"
     public static final String OKBUCK_DEFS = ".okbuck/defs/DEFS"
 
     public static final String OKBUCK_STATE_DIR = ".okbuck/state"


### PR DESCRIPTION
Was trying to figure out why am I getting this error when I'm trying to use custom Buck binary as recommended in [changelog for 0.32.2](https://github.com/uber/okbuck/releases/tag/v0.32.2):

```console
Could not find method buckBinary() for arguments [our.custom.buck:buck:someversion@pex] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.
```

Turned out changelog says to use `buckBinary` configuration while actual configuration name is `buck_binary` :trollface: 

Alternative fix would be to update changelog, but Gradle typically uses CamelCase for configuration names.