### PR TITLE
Use classpath_abi macro instead of classpath in lint genrule.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,3 +194,4 @@ gradle.buildFinished {
     "zip -d .okbuck/cache/org.hamcrest.hamcrest-library-1.3.jar LICENSE.txt".execute()
     "zip -d .okbuck/cache/org.hamcrest.hamcrest-integration-1.3.jar LICENSE.txt".execute()
 }
+

--- a/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/OkBuckGradlePlugin.groovy
@@ -105,6 +105,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
             okBuckExtension = okbuckExt
             kotlinExtension = kotlin
             scalaExtension = scala
+            experimentalExtension = experimental
         })
         okBuck.dependsOn(setupOkbuck)
 

--- a/buildSrc/src/main/groovy/com/uber/okbuck/composer/base/BuckRuleComposer.java
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/composer/base/BuckRuleComposer.java
@@ -71,12 +71,4 @@ public abstract class BuckRuleComposer {
     public static String toLocation(final String target) {
         return "$(location " + target + ")";
     }
-
-    public static String toClasspath(final String target) {
-        return "$(classpath " + target + ")";
-    }
-
-    public static String toClasspathFile(final String target) {
-        return "$(@classpath " + target + ")";
-    }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
@@ -1,6 +1,7 @@
 package com.uber.okbuck.core.task;
 
 import com.uber.okbuck.OkBuckGradlePlugin;
+import com.uber.okbuck.core.annotation.Experimental;
 import com.uber.okbuck.core.model.base.ProjectType;
 import com.uber.okbuck.core.util.FileUtil;
 import com.uber.okbuck.core.util.GroovyUtil;
@@ -8,6 +9,7 @@ import com.uber.okbuck.core.util.KotlinUtil;
 import com.uber.okbuck.core.util.ProguardUtil;
 import com.uber.okbuck.core.util.ProjectUtil;
 import com.uber.okbuck.core.util.ScalaUtil;
+import com.uber.okbuck.extension.ExperimentalExtension;
 import com.uber.okbuck.extension.KotlinExtension;
 import com.uber.okbuck.extension.OkBuckExtension;
 import com.uber.okbuck.extension.ScalaExtension;
@@ -31,6 +33,9 @@ import static com.uber.okbuck.OkBuckGradlePlugin.OKBUCK_DEFS;
 @SuppressWarnings({"WeakerAccess", "CanBeFinal", "unused", "ResultOfMethodCallIgnored", "NewApi"})
 public class OkBuckTask extends DefaultTask {
 
+    public static final String CLASSPATH_MACRO = "classpath";
+    public static final String CLASSPATH_ABI_MACRO = "classpath_abi";
+
     @Nested
     public OkBuckExtension okBuckExtension;
 
@@ -39,6 +44,9 @@ public class OkBuckTask extends DefaultTask {
 
     @Nested
     public ScalaExtension scalaExtension;
+
+    @Nested
+    public ExperimentalExtension experimentalExtension;
 
     public OkBuckTask() {
         // Never up to date; this task isn't safe to run incrementally.
@@ -68,6 +76,7 @@ public class OkBuckTask extends DefaultTask {
         }
 
         generate(okBuckExtension,
+                experimentalExtension,
                 hasGroovyLib ? GroovyUtil.GROOVY_HOME_LOCATION : null,
                 hasKotlinLib ? KotlinUtil.KOTLIN_HOME_LOCATION : null,
                 hasScalaLib ? ScalaUtil.SCALA_HOME_LOCATION : null);
@@ -103,6 +112,7 @@ public class OkBuckTask extends DefaultTask {
 
     private void generate(
             OkBuckExtension okbuckExt,
+            ExperimentalExtension experimentalExt,
             @Nullable String groovyHome,
             @Nullable String kotlinHome,
             @Nullable String scalaHome) {
@@ -113,14 +123,28 @@ public class OkBuckTask extends DefaultTask {
             throw new RuntimeException(e);
         }
 
+        String classpathMacro = CLASSPATH_MACRO;
+        if (experimentalExt.lintWithClasspathAbi) {
+            classpathMacro = CLASSPATH_MACRO;
+        }
+
         // Setup defs
-        new BuckDefs().resourceExcludes(okBuckExtension.excludeResources
-                .stream()
-                .map(s -> "'" + s + "'")
-                .collect(Collectors.toSet())).render(okbuckDefs());
-        Set<String> defs = okbuckExt.extraDefs.stream()
-                .map(it -> "//" + FileUtil.getRelativePath(getProject().getRootDir(), it))
-                .collect(Collectors.toSet());
+        new BuckDefs()
+                .resourceExcludes(
+                        okBuckExtension.excludeResources
+                                .stream()
+                                .map(s -> "'" + s + "'")
+                                .collect(Collectors.toSet()))
+                .classpathMacro(classpathMacro)
+                .render(okbuckDefs());
+
+        Set<String> defs =
+                okbuckExt
+                        .extraDefs
+                        .stream()
+                        .map(it -> "//" + FileUtil.getRelativePath(getProject().getRootDir(), it))
+                        .collect(Collectors.toSet());
+
         defs.add("//" + OKBUCK_DEFS);
 
         // generate .buckconfig.local

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/ExperimentalExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/ExperimentalExtension.java
@@ -9,4 +9,9 @@ public class ExperimentalExtension {
      * Whether transform rules are to be generated
      */
     public boolean transform = false;
+
+    /**
+     * Whether to use classpath_abi for lint or not
+     */
+    public boolean lintWithClasspathAbi = false;
 }

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckDefs.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckDefs.rocker.raw
@@ -1,5 +1,5 @@
 @import java.util.Collection
-@args (Collection resourceExcludes)
+@args (Collection resourceExcludes, String classpathMacro)
 import os, re
 
 
@@ -86,7 +86,7 @@ def okbuck_lint(
     bash = "export ANDROID_LINT_JARS=\"{}\"; PROJECT_ROOT=`echo '{}' | sed 's|buck-out.*||'`; ".format(':'.join(map(toLocation, custom_lints)), toLocation(':' + manifest_copy))
 
     if has_srcs:
-        bash += "CP_FILE=`sed 's/@@//' <<< $(@@classpath :src_{})`; ".format(variant)
+        bash += "CP_FILE=`sed 's/@@//' <<< $(@@@(classpathMacro) :src_{})`; ".format(variant)
         bash += 'sed -i.bak -e "s|$PROJECT_ROOT||g" -e "s|\'||g" $CP_FILE; '
 
     bash += 'mkdir -p $OUT; LOGFILE=$OUT/lint.log; trap "rv=\$?; if [ \$rv != 0 ] ; then cat \$LOGFILE 1>&2 ; fi ; rm -f \$LOGFILE; exit \$rv" EXIT;  java -Djava.awt.headless=true -Dcom.android.tools.lint.workdir=$PROJECT_ROOT '


### PR DESCRIPTION
Running android lint on a target only needs dependent libraries class-abi,
i.e doesn’t need to rerun lint if there are no api changes in the dependent
libraries.

Using classpath_abi returns class-abi jars of the dependencies instead of
the class jar. (Buck pr - https://github.com/facebook/buck/pull/1780)

Usage: $(@classpath_abi :<target_path>)

To enable using classpath_abi, add the experimental extension

```
    okbuck {
        experimental {
            lintWithClasspathAbi = true
        }
    }
```
