### PR TITLE
Only get annotation processor classes from the configuration’s first level dependencies.

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/ExternalDependency.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/ExternalDependency.java
@@ -95,9 +95,17 @@ public final class ExternalDependency {
         private final String group;
         private final String name;
 
-        VersionlessDependency(String group, String name) {
+        public VersionlessDependency(String group, String name) {
             this.group = group;
             this.name = name;
+        }
+
+        public String getGroup() {
+            return group;
+        }
+
+        public String getName() {
+            return name;
         }
 
         @Override

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/base/TargetCache.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/base/TargetCache.java
@@ -32,9 +32,6 @@ import static com.uber.okbuck.core.util.LintUtil.LINT_DEPS_CACHE;
 
 public class TargetCache {
 
-    private static final Converter<String, String> NAME_CONVERTER =
-            CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.LOWER_HYPHEN);
-
     private final Map<Project, Map<String, Target>> store = new HashMap<>();
     private final Map<Project, Map<String, Target>> artifactNameToTarget = new HashMap<>();
     private final Map<String, String> lintConfig = new ConcurrentHashMap<>();


### PR DESCRIPTION
Prevents adding annotation processor classes from transitive dependencies.