### PR TITLE
Fix module version computation

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyUtils.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyUtils.java
@@ -63,11 +63,9 @@ public final class DependencyUtils {
         if (baseFileName.length() > 0) {
             int versionIndex = fileNameString.lastIndexOf(version);
             if (versionIndex > -1) {
-                return fileNameString.substring(versionIndex);
+                return baseFileName.substring(versionIndex);
             } else {
-                throw new IllegalStateException(String.format(
-                        "Version string %s not present in %s module filename",
-                        version, fileNameString));
+                return version;
             }
         } else {
             throw new IllegalStateException(String.format(


### PR DESCRIPTION
- Use baseFileName to get the substring so it doesn’t include the extension.
- Return version if the filename doesn’t have a version.