### PR TITLE
Initialize IntelliJ & Experimental extensions with default ones

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
@@ -135,11 +135,10 @@ public class OkBuckExtension {
         buckProjects = project.getSubprojects();
     }
 
-    private IntellijExtension intellijExtension;
-    private ExperimentalExtension experimentalExtension;
+    private IntellijExtension intellijExtension = new IntellijExtension();
+    private ExperimentalExtension experimentalExtension = new ExperimentalExtension();
 
     public void intellij(Action<IntellijExtension> container) {
-        this.intellijExtension = new IntellijExtension();
         container.execute(intellijExtension);
     }
 
@@ -148,7 +147,6 @@ public class OkBuckExtension {
     }
 
     public void experimental(Action<ExperimentalExtension> container) {
-        this.experimentalExtension = new ExperimentalExtension();
         container.execute(experimentalExtension);
     }
 


### PR DESCRIPTION
This is to prevent NPE when the extensions are not specified in okbuck extension.

Resolves: https://github.com/uber/okbuck/issues/633