### PR TITLE
Keep annotation processor plugins rule name’s length small

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/AnnotationProcessorCache.java
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/AnnotationProcessorCache.java
@@ -26,8 +26,8 @@ import java.util.function.Function;
  * Keeps a cache of the annotation processor dependencies and its scope.
  */
 public class AnnotationProcessorCache {
-    private final static String AUTO_VALUE_GROUP = "com.google.auto.value";
-    private final static String AUTO_VALUE_NAME = "auto-value";
+    public final static String AUTO_VALUE_GROUP = "com.google.auto.value";
+    public final static String AUTO_VALUE_NAME = "auto-value";
 
     private final Project project;
     private final String processorBuckFile;


### PR DESCRIPTION
Compute MD5 hash of the appended UID and add it to the auto value dependency 
to prevent them from being too long.

Previous:
```
java_annotation_processor(
    name = 'processor_com.google.auto.value-auto-value-1.6-com.google.auto.value-auto-value-annotations-1.6-com.ryanharter.auto.value-auto-value-gson-0.7.0',
    processor_classes = [
        'com.google.auto.value.extension.memoized.processor.MemoizedValidator',
        'com.google.auto.value.processor.AutoAnnotationProcessor',
        'com.google.auto.value.processor.AutoOneOfProcessor',
```

New:
```
java_annotation_processor(
    name = 'processor_com.google.auto.value-auto-value-1.6__525046afa7fcbcf1dcd36f17908d83ff',
    processor_classes = [
        'com.google.auto.value.extension.memoized.processor.MemoizedValidator',
        'com.google.auto.value.processor.AutoAnnotationProcessor',
        'com.google.auto.value.processor.AutoOneOfProcessor',
```

Fixes `File name too long` error.