### PR TITLE
Use ConcurrentHashMap in annotation processor cache to prevent any race condition

### DIFF
--- a/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/AnnotationProcessorCache.java
+++ b/buildSrc/src/main/groovy/com/uber/okbuck/core/model/base/AnnotationProcessorCache.java
@@ -16,10 +16,10 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 /**
@@ -32,7 +32,7 @@ public class AnnotationProcessorCache {
     private final Project project;
     private final String processorBuckFile;
 
-    private Map<Set<Dependency>, Scope> dependencyToScopeMap = new HashMap<>();
+    private Map<Set<Dependency>, Scope> dependencyToScopeMap = new ConcurrentHashMap<>();
 
     public AnnotationProcessorCache(Project project, String processorBuckFile) {
         this.project = project;


### PR DESCRIPTION
AnnotationProcessorCache is being called by multiple tasks on different 
threads, changing dependencyToScopeMap to ConcurrentHashMap should prevent
any race condition.