### PR TITLE
Adding maven coords to java binary

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/composer/jvm/JvmLibraryRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/jvm/JvmLibraryRuleComposer.java
@@ -65,6 +65,7 @@ public final class JvmLibraryRuleComposer extends JvmBuckRuleComposer {
       rulesBuilder.add(
           new JvmBinaryRule()
               .mainClassName(target.getMainClass())
+              .mavenCoords(target.getMavenCoords())
               .excludes(target.getExcludes())
               .defaultVisibility()
               .name(bin(target))

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/jvm/JvmBinaryRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/jvm/JvmBinaryRule.rocker.raw
@@ -14,5 +14,8 @@ Set excludes
     }
     ],
 }
+@if (mavenCoords != null) {
+    maven_coords = '@mavenCoords',
+}
     deps = [ ':src_main' ] + lib_deps,
 }


### PR DESCRIPTION
In addition to adding maven coordinates to Java Libraries, we should also expose the same coordinates to the java binary for maven upload.