### PR TITLE
fixing skip check bug

### DIFF
--- a/buckw
+++ b/buckw
@@ -236,7 +236,7 @@ setupBuckRun ( ) {
 # Handle parameters and flags
 handleParams ( ) {
    # Go directly to the kill command, help command, or --help option. Do not run okbuck.
-   if [[ "kill" == $1 || "help" == $1 || $@ == *"--help"* || $@ == *"-h"* ]]; then
+   if [[ "kill" == $1 || "help" == $1 || $@ == *"--help"* || $@ == *" -h "* ]]; then
       SKIP_OKBUCK=true
    fi
 }

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckWrapper.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckWrapper.rocker.raw
@@ -231,7 +231,7 @@ setupBuckRun ( ) {
 # Handle parameters and flags
 handleParams ( ) {
    # Go directly to the kill command, help command, or --help option. Do not run okbuck.
-   if [[ "kill" == $1 || "help" == $1 || $@@ == *"--help"* || $@@ == *"-h"* ]]; then
+   if [[ "kill" == $1 || "help" == $1 || $@@ == *"--help"* || $@@ == *" -h "* ]]; then
       SKIP_OKBUCK=true
    fi
 }


### PR DESCRIPTION
The current check passed for modules that contains -h in their name, not only the flag -h. 

Fixes #676 