### PR TITLE
Fixing bug introduced by pull/678

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/ExternalDependency.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/ExternalDependency.java
@@ -51,7 +51,8 @@ public final class ExternalDependency {
       return false;
     }
     ExternalDependency that = (ExternalDependency) o;
-    return Objects.equals(version, that.version)
+    return Objects.equals(classifier, that.classifier)
+        && Objects.equals(version, that.version)
         && Objects.equals(group, that.group)
         && Objects.equals(name, that.name);
   }


### PR DESCRIPTION
Previously okBuck relied on version to identify 2 unique dependencies (and by the moment it got to okbuck, atrifact had chance to have 2 separate verisons only if because of classifiers)
after pull/678 these artifacts became equal, this producing false uniqueness behavior.