### PR TITLE
implementing equals and hash code for Rule

### DIFF
--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/core/Rule.java
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/core/Rule.java
@@ -11,6 +11,7 @@ import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public abstract class Rule<T extends Rule> extends DefaultRockerModel {
@@ -99,5 +100,26 @@ public abstract class Rule<T extends Rule> extends DefaultRockerModel {
       builder.add(o.toString());
     }
     return builder.build();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Rule<?> rule = (Rule<?>) o;
+    return Objects.equals(ruleType, rule.ruleType) &&
+        Objects.equals(name, rule.name) &&
+        Objects.equals(visibility, rule.visibility) &&
+        Objects.equals(labels, rule.labels) &&
+        Objects.equals(extraBuckOpts, rule.extraBuckOpts);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(ruleType, name, visibility, labels, extraBuckOpts);
   }
 }

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/core/Rule.java
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/core/Rule.java
@@ -111,15 +111,11 @@ public abstract class Rule<T extends Rule> extends DefaultRockerModel {
       return false;
     }
     Rule<?> rule = (Rule<?>) o;
-    return Objects.equals(ruleType, rule.ruleType) &&
-        Objects.equals(name, rule.name) &&
-        Objects.equals(visibility, rule.visibility) &&
-        Objects.equals(labels, rule.labels) &&
-        Objects.equals(extraBuckOpts, rule.extraBuckOpts);
+    return Objects.equals(name, rule.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(ruleType, name, visibility, labels, extraBuckOpts);
+    return Objects.hash(name);
   }
 }


### PR DESCRIPTION
fixes #663 

The class **Rule** needs to implement **HashCode** so it can work with **LinkedHashSet**. 

In the class BuckFileGenerator I can see an intention to filter the rules by using a LinkedHashSet:

```
              default:
                  throw new IllegalArgumentException(
                      "Okbuck does not support "
                          + project
                          + "type projects yet. Please use the extension option okbuck.buckProjects to exclude "
                          + project);
              }
            });

    // de-dup rules by name
    return new ArrayList<>(new LinkedHashSet<>(rules));
  }
```

But **LinkedHashSet** doesn't work properly with classes that does not implement _hashCode()_, so the filter wont work as expected. 

I am not including deps in the equals and hashCode because that are rules being generated with some small differences in the `deps`. That seams to be another problem. 

This bug was introduced when converting BuckFileGenerator from Groovy to Java. 