### PR TITLE
Upgrade Gradle and AGP versions

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 def versions = [
-        androidPlugin      : "3.1.2",
+        androidPlugin      : "3.2.0-beta01",
         androidTools       : "26.1.2",
         butterKnife        : "9.0.0-20180416.155017-37",
         butterKnifeCompiler: "9.0.0-20180416.155025-37",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/transform-cli/src/main/java/com/uber/okbuck/transform/FileUtil.java
+++ b/transform-cli/src/main/java/com/uber/okbuck/transform/FileUtil.java
@@ -6,17 +6,15 @@ import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.stream.Stream;
 
 final class FileUtil {
 
   private FileUtil() {}
 
   static void deleteDirectory(File path) {
-    try {
-      Files.walk(path.toPath(), FileVisitOption.FOLLOW_LINKS)
-          .sorted(Comparator.reverseOrder())
-          .map(Path::toFile)
-          .forEach(File::delete);
+    try (Stream<Path> walk = Files.walk(path.toPath(), FileVisitOption.FOLLOW_LINKS)) {
+      walk.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
     } catch (IOException ignored) {
     }
   }


### PR DESCRIPTION
- Upgrade Gradle to 4.8.1
- Upgrade AGP to 3.2.0-beta01 and change breaking api (https://issuetracker.google.com/issues/76031225)

- According to Files api docs, the streams returned by Files.walk and Files.lines must be properly closed to release the resources. This plugs a few file leaks in okbuck
- Fixes #686