### PR TITLE
Fix a NullPointerException happening on the use of ndkCompile.

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidAppTarget.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidAppTarget.java
@@ -3,6 +3,7 @@ package com.uber.okbuck.core.model.android;
 import com.android.build.gradle.AppExtension;
 import com.android.build.gradle.api.ApplicationVariant;
 import com.android.build.gradle.api.BaseVariant;
+import com.android.build.gradle.tasks.NdkCompile;
 import com.android.builder.model.SigningConfig;
 import com.android.manifmerger.ManifestMerger2;
 import com.google.common.base.Preconditions;
@@ -49,7 +50,13 @@ public class AndroidAppTarget extends AndroidLibTarget {
     minifyEnabled = getBaseVariant().getBuildType().isMinifyEnabled();
     keystore = extractKeystore();
 
-    final Set<String> filters = getBaseVariant().getNdkCompile().getAbiFilters();
+    BaseVariant baseVariant = getBaseVariant();
+    NdkCompile ndkCompile = baseVariant.getNdkCompile();
+    Set<String> filters = null;
+    if (ndkCompile != null) {
+      filters = ndkCompile.getAbiFilters();
+    }
+
     if (filters == null) {
       cpuFilters = ImmutableSet.of();
     } else {


### PR DESCRIPTION
```
Caused by: java.lang.NullPointerException
        at com.uber.okbuck.core.model.android.AndroidAppTarget.<init>(AndroidAppTarget.java:52)
        at com.uber.okbuck.core.model.android.AndroidAppTarget.<init>(AndroidAppTarget.java:96)
        at com.uber.okbuck.core.model.base.TargetCache.getTargets(TargetCache.java:38)
        at com.uber.okbuck.OkBuckGradlePlugin.lambda$null$4(OkBuckGradlePlugin.java:143)
        at com.uber.okbuck.OkBuckGradlePlugin.lambda$null$6(OkBuckGradlePlugin.java:143)
        at org.gradle.api.internal.AbstractTask$TaskActionWrapper.execute(AbstractTask.java:794)
        at org.gradle.api.internal.AbstractTask$TaskActionWrapper.execute(AbstractTask.java:761)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter$1.run(ExecuteActionsTaskExecuter.java:131)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:317)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:309)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:185)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:97)
        at org.gradle.internal.operations.DelegatingBuildOperationExecutor.run(DelegatingBuildOperationExecutor.java:31)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeAction(ExecuteActionsTaskExecuter.java:120)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:99)
        ... 32 more
```