### PR TITLE
Do not pickup source jars which are not actually zip files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,10 @@ jobs:
          keys:
            - gradle-cache-{{ checksum "dependencies.gradle" }}
       - run:
+          name: Cleanup snapshot sources
+          command: rm -rf ~/.gradle/caches/modules-2/files-2.1/com.jakewharton/butterknife*
+          shell: "/bin/bash"
+      - run:
           name: Run okbuck
           command: SKIP_OKBUCK= EXTRA_OKBUCK_ARGS="-Dorg.gradle.daemon=false" ./buckw --version
           shell: "/bin/bash"

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyCache.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyCache.java
@@ -184,7 +184,7 @@ public class DependencyCache {
     String key = dependency.getCacheName();
     String sourcesJarPath = sources.get(key);
 
-    if (sourcesJarPath == null || !Files.exists(Paths.get(sourcesJarPath))) {
+    if (sourcesJarPath == null || !FileUtil.isZipFile(new File(sourcesJarPath))) {
       sourcesJarPath = "";
       if (!DependencyUtils.isWhiteListed(dependency.depFile)) {
         String sourcesJarName = dependency.getSourceCacheName(false);
@@ -201,7 +201,10 @@ public class DependencyCache {
                         "includes", ImmutableList.of("**/" + sourcesJarName)));
 
             try {
-              sourcesJarPath = sourceJars.getSingleFile().getAbsolutePath();
+              File maybeSourcesJar = sourceJars.getSingleFile();
+              if (FileUtil.isZipFile(maybeSourcesJar)) {
+                sourcesJarPath = maybeSourcesJar.getAbsolutePath();
+              }
             } catch (IllegalStateException ignored) {
               if (sourceJars.getFiles().size() > 1) {
                 throw new IllegalStateException(

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/FileUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/FileUtil.java
@@ -1,6 +1,12 @@
 package com.uber.okbuck.core.util;
 
+import org.apache.commons.io.FileUtils;
+import org.gradle.api.Project;
+
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -9,8 +15,6 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collection;
 import java.util.Set;
-import org.apache.commons.io.FileUtils;
-import org.gradle.api.Project;
 
 public final class FileUtil {
 
@@ -62,6 +66,18 @@ public final class FileUtil {
             }
           });
     } catch (IOException ignored) {
+    }
+  }
+
+  public static boolean isZipFile(File file) {
+    if (!file.exists() || file.isDirectory() || !file.canRead() || file.length() < 4) {
+      return false;
+    }
+    try (DataInputStream in = new DataInputStream(
+        new BufferedInputStream(new FileInputStream(file)))) {
+      return in.readInt() == 0x504b0304;
+    } catch (IOException ignored) {
+      return false;
     }
   }
 }


### PR DESCRIPTION
Some artifacts like `com.google.code.findbugs:annotations` and `com.google.code.findbugs:jsr305` have `-sources` jar artifacts available on mavencentral, but they are not actual source jars which cause intellij to fail with warning logs like

```
WARN - penapi.vfs.impl.jar.JarHandler - error in opening zip file: .okbuck/cache/com.google.code.findbugs--annotations--2.0.1-sources.jar
java.util.zip.ZipException: error in opening zip file
	at java.util.zip.ZipFile.open(Native Method)
	at java.util.zip.ZipFile.<init>(ZipFile.java:219)
	at java.util.zip.ZipFile.<init>(ZipFile.java:149)
	at java.util.zip.ZipFile.<init>(ZipFile.java:120)
	at com.intellij.openapi.vfs.impl.ZipHandler$1.createAccessor(ZipHandler.java:45)
	at com.intellij.openapi.vfs.impl.ZipHandler$1.createAccessor(ZipHandler.java:39)
	at com.intellij.util.io.FileAccessorCache.createHandle(FileAccessorCache.java:60)
	at com.intellij.util.io.FileAccessorCache.get(FileAccessorCache.java:52)
	at com.intellij.openapi.vfs.impl.ZipHandler.getCachedZipFileHandle(ZipHandler.java:83)
	at com.intellij.openapi.vfs.impl.jar.JarHandler.createEntriesMap(JarHandler.java:92)
	at com.intellij.openapi.vfs.impl.ArchiveHandler.getEntriesMap(ArchiveHandler.java:197)
	at com.intellij.openapi.vfs.impl.ArchiveHandler.getEntryInfo(ArchiveHandler.java:181)
	at com.intellij.openapi.vfs.impl.ArchiveHandler.getAttributes(ArchiveHandler.java:82)
	at com.intellij.openapi.vfs.newvfs.ArchiveFileSystem.getAttributes(ArchiveFileSystem.java:151)
	at com.intellij.openapi.vfs.newvfs.persistent.PersistentFSImpl.getId(PersistentFSImpl.java:397)
```

This change makes okbuck only accept actual zip files for source archives.