### PR TITLE
Add ability to filter entries out of android lint classpath

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
@@ -139,6 +139,7 @@ public class OkBuckTask extends DefaultTask {
         .lintJvmArgs(okbuckExt.getLintExtension().jvmArgs)
         .enableLint(!okbuckExt.getLintExtension().disabled)
         .externalDependencyCache(okbuckExt.externalDependencyCache)
+        .classpathExclusionRegex(okbuckExt.getLintExtension().classpathExclusionRegex)
         .render(okbuckDefs());
 
     Set<String> defs =

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/LintExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/LintExtension.java
@@ -17,6 +17,9 @@ public class LintExtension {
   /** JVM arguments when invoking lint */
   public String jvmArgs = "-Xmx1024m";
 
+  /** Classpath entries matching regex to exclude during lint */
+  @Nullable public String classpathExclusionRegex = null;
+
   LintExtension(Project project) {
     version = LintManager.getDefaultLintVersion(project);
   }

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckDefs.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckDefs.rocker.raw
@@ -4,8 +4,10 @@ Collection resourceExcludes,
 String classpathMacro,
 String lintJvmArgs,
 String externalDependencyCache,
-boolean enableLint
+boolean enableLint,
+String classpathExclusionRegex
 )
+
 import os, re
 
 
@@ -88,7 +90,13 @@ def okbuck_lint(
     bash += "export ANDROID_LINT_JARS=\"$PREBUILT_AAR_LINT_JARS{}\"; PROJECT_ROOT=`echo '{}' | sed 's|buck-out.*||'`; ".format(':'.join(map(toLocation, custom_lints)), toLocation(manifest))
 
     if has_srcs:
+@if(classpathExclusionRegex != null) {
+        bash += "TMP_CP_FILE=`sed 's/@@//' <<< $(@@@(classpathMacro) :src_{})`; ".format(variant)
+        bash += "tr ':' '\\n' < $TMP_CP_FILE | sed -e '/@classpathExclusionRegex/d' > tmp_cp_file; tr '\\n' ':' < tmp_cp_file > cp_file; "
+        bash += "CP_FILE=cp_file; "
+} else {
         bash += "CP_FILE=`sed 's/@@//' <<< $(@@@(classpathMacro) :src_{})`; ".format(variant)
+}
         bash += 'sed -i.bak -e "s|$PROJECT_ROOT||g" -e "s|\'||g" $CP_FILE; '
 
     bash += 'mkdir -p $OUT; LOGFILE=$OUT/lint.log; trap "rv=$?; if [ \$rv != 0 ] ; then cat $LOGFILE 1>&2 ; fi ; rm -f $LOGFILE; exit $rv" EXIT;  java -Djava.awt.headless=true -Dcom.android.tools.lint.workdir=$PROJECT_ROOT '


### PR DESCRIPTION
This lets us exclude Nullaway's jar infer model jars for example via a regex