### PR TITLE
Move okbuck cache to workspace

### DIFF
--- a/buckw
+++ b/buckw
@@ -66,7 +66,7 @@ OKBUCK_DIR="$SCRIPT_DIR/.okbuck"
 MAX_DISPLAY_CHANGES=10
 WATCHMAN_TIMEOUT=10
 WATCHMAN_FAILED="WATCHMAN FAILED"
-BUCK_BINARY_DIR="$OKBUCK_DIR/cache/buck_binary"
+BUCK_BINARY_DIR="$OKBUCK_DIR/workspace/buck_binary"
 
 # Timeout a call and exit early. This can be called via timeout <time> <command>.
 timeout( ) {

--- a/buildSrc/src/main/java/com/uber/okbuck/OkBuckGradlePlugin.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/OkBuckGradlePlugin.java
@@ -24,8 +24,6 @@ import com.uber.okbuck.extension.ScalaExtension;
 import com.uber.okbuck.extension.WrapperExtension;
 import com.uber.okbuck.generator.BuckFileGenerator;
 import com.uber.okbuck.wrapper.BuckWrapperTask;
-
-import java.io.File;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -52,7 +50,7 @@ import org.gradle.api.artifacts.Configuration;
 public class OkBuckGradlePlugin implements Plugin<Project> {
   public static final String BUCK = "BUCK";
   public static final String OKBUCK = "okbuck";
-  public static final String DEFAULT_CACHE_PATH = ".okbuck/cache";
+  public static final String WORKSPACE_PATH = ".okbuck/workspace";
   public static final String GROUP = "okbuck";
   public static final String BUCK_LINT = "buckLint";
   public static final String OKBUCK_DEFS = ".okbuck/defs/DEFS";
@@ -63,8 +61,8 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
   private static final String OKBUCK_CLEAN = "okbuckClean";
   private static final String BUCK_WRAPPER = "buckWrapper";
   private static final String FORCED_OKBUCK = "forcedOkbuck";
-  private static final String PROCESSOR_BUCK_FILE = ".okbuck/cache/processor/BUCK";
-  private static final String LINT_BUCK_FILE = ".okbuck/cache/lint/BUCK";
+  private static final String PROCESSOR_BUCK_FILE = WORKSPACE_PATH + "/processor/BUCK";
+  private static final String LINT_BUCK_FILE = WORKSPACE_PATH + "/lint/BUCK";
 
   public static final String OKBUCK_STATE = OKBUCK_STATE_DIR + "/STATE";
   public final Map<Project, Map<String, Scope>> scopes = new ConcurrentHashMap<>();

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/jvm/JvmBuckRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/jvm/JvmBuckRuleComposer.java
@@ -2,6 +2,7 @@ package com.uber.okbuck.composer.jvm;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import com.uber.okbuck.OkBuckGradlePlugin;
 import com.uber.okbuck.composer.base.BuckRuleComposer;
 import com.uber.okbuck.core.model.base.Scope;
 import com.uber.okbuck.core.model.base.Target;
@@ -120,6 +121,7 @@ public class JvmBuckRuleComposer extends BuckRuleComposer {
    * @return Plugin rule path.
    */
   private static String getApPluginRulePath(String pluginUID) {
-    return String.format("//.okbuck/cache/processor:%s", getApPluginRuleName(pluginUID));
+    return String.format(
+        "//" + OkBuckGradlePlugin.WORKSPACE_PATH + "/processor:%s", getApPluginRuleName(pluginUID));
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/BuckManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/BuckManager.java
@@ -15,7 +15,7 @@ import org.gradle.api.artifacts.Configuration;
 public final class BuckManager {
 
   private static final String BUCK_BINARY_LOCATION =
-      OkBuckGradlePlugin.DEFAULT_CACHE_PATH + "/buck_binary";
+      OkBuckGradlePlugin.WORKSPACE_PATH + "/buck_binary";
 
   private static final String BUCK_BINARY_CONFIGURATION = "buckBinary";
   private static final String JITPACK_URL = "https://jitpack.io";

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/GroovyManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/GroovyManager.java
@@ -21,7 +21,7 @@ public final class GroovyManager {
   private static final String GROOVY_DEPS_CONFIG = "okbuck_groovy_deps";
 
   public static final String GROOVY_HOME_LOCATION =
-      OkBuckGradlePlugin.DEFAULT_CACHE_PATH + "/groovy_installation";
+      OkBuckGradlePlugin.WORKSPACE_PATH + "/groovy_installation";
 
   private final Project rootProject;
   @Nullable private Set<String> dependencies;
@@ -66,8 +66,7 @@ public final class GroovyManager {
 
       String groovyAll = dependencies.iterator().next();
       Path fromPath = rootProject.file(groovyAll).toPath();
-      Path toPath =
-          groovyLibCache.resolve("groovy-" + groovyVersion + ".jar");
+      Path toPath = groovyLibCache.resolve("groovy-" + groovyVersion + ".jar");
 
       try {
         toPath.toFile().getParentFile().mkdirs();

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/KotlinManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/KotlinManager.java
@@ -5,13 +5,12 @@ import com.uber.okbuck.OkBuckGradlePlugin;
 import com.uber.okbuck.core.dependency.DependencyCache;
 import com.uber.okbuck.core.util.FileUtil;
 import com.uber.okbuck.core.util.ProjectUtil;
+import com.uber.okbuck.extension.OkBuckExtension;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import javax.annotation.Nullable;
-
-import com.uber.okbuck.extension.OkBuckExtension;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
@@ -19,7 +18,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 public final class KotlinManager {
 
   public static final String KOTLIN_HOME_LOCATION =
-      OkBuckGradlePlugin.DEFAULT_CACHE_PATH + "/kotlin_home";
+      OkBuckGradlePlugin.WORKSPACE_PATH + "/kotlin_home";
   public static final String KOTLIN_ANDROID_EXTENSIONS_MODULE = "kotlin-android-extensions";
   private static final String KOTLIN_ALLOPEN_MODULE = "kotlin-allopen";
   public static final String KOTLIN_KAPT_PLUGIN = "kotlin-kapt";
@@ -91,9 +90,11 @@ public final class KotlinManager {
       throw new IllegalStateException("kotlinVersion is not setup");
     }
 
-    Path fromPath = project
-        .file(Paths.get(okBuckExtension.externalDependencyCache, KOTLIN_LIBRARIES_CACHE_LOCATION))
-        .toPath();
+    Path fromPath =
+        project
+            .file(
+                Paths.get(okBuckExtension.externalDependencyCache, KOTLIN_LIBRARIES_CACHE_LOCATION))
+            .toPath();
     Path toPath = project.file(KOTLIN_LIBRARIES_LOCATION).toPath();
 
     FileUtil.deleteQuietly(toPath);

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/LintManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/LintManager.java
@@ -10,7 +10,6 @@ import com.uber.okbuck.core.util.FileUtil;
 import com.uber.okbuck.core.util.ProjectUtil;
 import com.uber.okbuck.template.common.ExportFile;
 import com.uber.okbuck.template.core.Rule;
-import com.uber.okbuck.template.java.Prebuilt;
 import com.uber.okbuck.template.jvm.JvmBinaryRule;
 import java.io.File;
 import java.io.IOException;
@@ -27,7 +26,7 @@ import org.gradle.api.Project;
 
 public final class LintManager {
 
-  private static final String LINT_DEPS_CACHE = OkBuckGradlePlugin.DEFAULT_CACHE_PATH + "/lint";
+  private static final String LINT_DEPS_CACHE = OkBuckGradlePlugin.WORKSPACE_PATH + "/lint";
   private static final String LINT_BINARY_RULE_NAME = "okbuck_lint";
 
   private static final String LINT_GROUP = "com.android.tools.lint";

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/ManifestMergerManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/ManifestMergerManager.java
@@ -23,7 +23,7 @@ public final class ManifestMergerManager {
   private static final String MANIFEST_MERGER_GROUP = "com.android.tools.build";
   private static final String MANIFEST_MERGER_MODULE = "manifest-merger";
   private static final String MANIFEST_MERGER_CACHE =
-      OkBuckGradlePlugin.DEFAULT_CACHE_PATH + "/manifest-merger";
+      OkBuckGradlePlugin.WORKSPACE_PATH + "/manifest-merger";
   private static final String CONFIGURATION_MANIFEST_MERGER = "manifest-merger";
   private static final ImmutableSet<String> MANIFEST_MERGER_EXCLUDES =
       ImmutableSet.of("META-INF/.*\\.SF", "META-INF/.*\\.DSA", "META-INF/.*\\.RSA");

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/RobolectricManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/RobolectricManager.java
@@ -17,8 +17,7 @@ import org.gradle.api.artifacts.Configuration;
 public final class RobolectricManager {
 
   private static final String ROBOLECTRIC_RUNTIME = "robolectricRuntime";
-  public static final String ROBOLECTRIC_CACHE =
-      OkBuckGradlePlugin.DEFAULT_CACHE_PATH + "/robolectric";
+  public static final String ROBOLECTRIC_CACHE = OkBuckGradlePlugin.WORKSPACE_PATH + "/robolectric";
 
   private final Project rootProject;
   @Nullable private ImmutableSet<String> dependencies;

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/ScalaManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/ScalaManager.java
@@ -15,7 +15,7 @@ public final class ScalaManager {
   private static final String SCALA_DEPS_CONFIG = "okbuck_scala_deps";
 
   public static final String SCALA_COMPILER_LOCATION =
-      OkBuckGradlePlugin.DEFAULT_CACHE_PATH + "/scala_installation";
+      OkBuckGradlePlugin.WORKSPACE_PATH + "/scala_installation";
 
   private final Project rootProject;
   @Nullable private Set<String> dependencies;

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/TransformManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/TransformManager.java
@@ -29,8 +29,7 @@ import org.gradle.api.Project;
 
 public final class TransformManager {
 
-  private static final String TRANSFORM_CACHE =
-      OkBuckGradlePlugin.DEFAULT_CACHE_PATH + "/transform";
+  private static final String TRANSFORM_CACHE = OkBuckGradlePlugin.WORKSPACE_PATH + "/transform";
   public static final String TRANSFORM_RULE = "//" + TRANSFORM_CACHE + ":okbuck_transform";
 
   public static final String CONFIGURATION_TRANSFORM = "transform";

--- a/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckCleanTask.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckCleanTask.java
@@ -70,6 +70,9 @@ public class OkBuckCleanTask extends DefaultTask {
         .map(p -> rootProjectPath.resolve(p).resolve(OkBuckGradlePlugin.BUCK))
         .forEach(FileUtil::deleteQuietly);
 
+    // Delete old .okbuck/cache dir
+    FileUtil.deleteQuietly(rootProjectPath.resolve(".okbuck/cache"));
+
     // Save generated project's BUCK file path
     Files.write(
         okbuckState.toPath(),

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/D8Util.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/D8Util.java
@@ -5,7 +5,7 @@ import java.io.File;
 
 public final class D8Util {
 
-  private static final String D8_CACHE = OkBuckGradlePlugin.DEFAULT_CACHE_PATH + "/d8";
+  private static final String D8_CACHE = OkBuckGradlePlugin.WORKSPACE_PATH + "/d8";
   private static final String RT_STUB_JAR = "rt-stub.jar";
   public static final String RT_STUB_JAR_RULE = "//" + D8_CACHE + ":" + RT_STUB_JAR;
 

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckDefs.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckDefs.rocker.raw
@@ -101,7 +101,7 @@ def okbuck_lint(
 
     bash += 'mkdir -p $OUT; LOGFILE=$OUT/lint.log; trap "rv=$?; if [ \$rv != 0 ] ; then cat $LOGFILE 1>&2 ; fi ; rm -f $LOGFILE; exit $rv" EXIT;  java -Djava.awt.headless=true -Dcom.android.tools.lint.workdir=$PROJECT_ROOT '
     bash += "@lintJvmArgs "
-    bash += "-classpath {} com.android.tools.lint.Main ".format(toLocation('//.okbuck/cache/lint:okbuck_lint'))
+    bash += "-classpath {} com.android.tools.lint.Main ".format(toLocation('//.okbuck/workspace/lint:okbuck_lint'))
 
     if has_srcs:
         bash += "--classpath $(location :src_{}) --libraries `cat $CP_FILE` ".format(variant)
@@ -140,7 +140,7 @@ def okbuck_manifest(
         secondary_manifests=[],
     ):
     cmds =[]
-    cmds.append("java -jar -Xmx256m $(location //.okbuck/cache/manifest-merger:okbuck_manifest_merger)")
+    cmds.append("java -jar -Xmx256m $(location //.okbuck/workspace/manifest-merger:okbuck_manifest_merger)")
     cmds.append("--main $SRCDIR/{}".format(main_manifest))
     if len(secondary_manifests) > 0:
         cmds.append("--overlays {}".format(" ".join(["$SRCDIR/" + m for m in secondary_manifests])))

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckWrapper.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckWrapper.rocker.raw
@@ -72,7 +72,7 @@ OKBUCK_DIR="$SCRIPT_DIR/.okbuck"
 MAX_DISPLAY_CHANGES=10
 WATCHMAN_TIMEOUT=10
 WATCHMAN_FAILED="WATCHMAN FAILED"
-BUCK_BINARY_DIR="$OKBUCK_DIR/cache/buck_binary"
+BUCK_BINARY_DIR="$OKBUCK_DIR/workspace/buck_binary"
 
 # Timeout a call and exit early. This can be called via timeout <time> <command>.
 timeout( ) {

--- a/transform-cli/src/main/java/com/uber/okbuck/transform/JarsTransformOutputProvider.java
+++ b/transform-cli/src/main/java/com/uber/okbuck/transform/JarsTransformOutputProvider.java
@@ -48,14 +48,14 @@ public class JarsTransformOutputProvider implements TransformOutputProvider {
      * path the parts in common plus the last folder (i.e. all the parts of the output folder).
      *
      * <p>Example of input path: ...mobile/okbuck/buck-out/bin/app
-     * /java_classes_preprocess_in_bin_prodDebug/buck-out/gen/.okbuck/cache/__app.rxscreenshotdetector-release
+     * /java_classes_preprocess_in_bin_prodDebug/buck-out/gen/.okbuck/workspace/__app.rxscreenshotdetector-release
      * .aar#aar_prebuilt_jar__/classes.jar
      *
      * <p>Example of output base folder: ...mobile/okbuck/buck-out/bin/app/
      * java_classes_preprocess_out_bin_prodDebug/
      *
      * <p>Example of output path: ...mobile/okbuck/buck-out/bin/app
-     * /java_classes_preprocess_out_bin_prodDebug/buck-out/gen/.okbuck/cache/__app.rxscreenshotdetector-release
+     * /java_classes_preprocess_out_bin_prodDebug/buck-out/gen/.okbuck/workspace/__app.rxscreenshotdetector-release
      * .aar#aar_prebuilt_jar__/classes.jar
      */
 

--- a/transform-cli/src/test/java/com/uber/okbuck/transform/JarsTransformOutputProviderTest.java
+++ b/transform-cli/src/test/java/com/uber/okbuck/transform/JarsTransformOutputProviderTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 public class JarsTransformOutputProviderTest {
 
   private static final String NAME =
-      "buck-out/bin/app/java_classes_preprocess_in_bin_prodDebug/buck-out/gen/.okbuck/cache/"
+      "buck-out/bin/app/java_classes_preprocess_in_bin_prodDebug/buck-out/gen/.okbuck/workspace/"
           + "__app.rxscreenshotdetector-release.aar#aar_prebuilt_jar__/classes.jar";
 
   private static final String INPUT = "buck-out/bin/app/java_classes_preprocess_in_bin_prodDebug/";
@@ -20,7 +20,7 @@ public class JarsTransformOutputProviderTest {
       "buck-out/bin/app/java_classes_preprocess_out_bin_prodDebug/";
 
   private static final String EXPECTED_OUTPUT_JAR =
-      "buck-out/bin/app/java_classes_preprocess_out_bin_prodDebug/buck-out/gen/.okbuck/cache/"
+      "buck-out/bin/app/java_classes_preprocess_out_bin_prodDebug/buck-out/gen/.okbuck/workspace/"
           + "__app.rxscreenshotdetector-release.aar#aar_prebuilt_jar__/classes.jar";
 
   private File inputJarFile;


### PR DESCRIPTION
- Move `.okbuck/cache` to `.okbuck/workspace`
- Delete old `.okbuck/cache` directory to avoid old buck rules from hanging around
- Prepare to move `3rdparty` inside `.okbuck` by default
