### PR TITLE
Update AGP, support lib and build tools to latest

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 def versions = [
-        androidPlugin      : "3.2.0-rc03",
-        androidTools       : "26.2.0-rc03",
+        androidPlugin      : "3.2.0",
+        androidTools       : "26.2.0",
         butterKnife        : "9.0.0-SNAPSHOT",
         dagger             : "2.15",
         kotlin             : "1.2.61",
@@ -29,7 +29,7 @@ def build = [
 ]
 
 def buildConfig = [
-        buildTools: "28.0.2",
+        buildTools: "28.0.3",
         compileSdk: 28,
         minSdk    : 16,
         targetSdk : 28,

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ def versions = [
         kotlin             : "1.2.61",
         leakCanary         : "1.5.4",
         rocker             : "0.23.0",
-        support            : "27.1.1",
+        support            : "28.0.0",
 ]
 
 def build = [


### PR DESCRIPTION
- Update AGP to 3.2.0
- Update build tools to 28.0.3
- Update support to 28.0.0