### PR TITLE
Add ability to configure buck's resource_union package name

### DIFF
--- a/app/src/main/java/com/uber/okbuck/example/MainActivity.java
+++ b/app/src/main/java/com/uber/okbuck/example/MainActivity.java
@@ -75,7 +75,7 @@ public class MainActivity extends AppCompatActivity {
     mTextView.setText(
         String.format(
             "%s %s, --from %s.",
-            getString(R.string.dummy_library_android_str),
+            getString(com.uber.okbuck.example.dummylibrary.R.string.dummy_library_android_str),
             mDummyAndroidClass.getAndroidWord(this),
             mDummyJavaClass.getJavaWord()));
 
@@ -112,7 +112,7 @@ public class MainActivity extends AppCompatActivity {
     GithubRepo repo = GithubRepo.create(100, "OkBuck", "auto buck");
     Toast.makeText(this, repo.name() + ": " + repo.description(), Toast.LENGTH_SHORT).show();
 
-    KotlinDataClass data = new KotlinDataClass("foo", R.string.foo);
+    KotlinDataClass data = new KotlinDataClass("foo", com.uber.okbuck.kotlin.android.R.string.foo);
     Pojo pojo = new Pojo();
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ def addCommonConfigurationForAndroidModules(Project project) {
     }
 
     def variants
-    if (project.plugins.hasPlugin("com.android.application") || project.plugins.hasPlugin("com.android.application")) {
+    if (project.plugins.hasPlugin("com.android.library") || project.plugins.hasPlugin("com.android.application")) {
         project.android {
             signingConfigs {
                 debug {
@@ -168,6 +168,7 @@ okbuck {
 
     test {
         espresso = true
+        espressoForLibraries = true
         robolectric = true
     }
 

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidBuckRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidBuckRuleComposer.java
@@ -1,9 +1,7 @@
 package com.uber.okbuck.composer.android;
 
 import com.uber.okbuck.composer.jvm.JvmBuckRuleComposer;
-import com.uber.okbuck.core.model.android.AndroidAppInstrumentationTarget;
 import com.uber.okbuck.core.model.android.AndroidAppTarget;
-import com.uber.okbuck.core.model.android.AndroidLibInstrumentationTarget;
 import com.uber.okbuck.core.model.android.AndroidTarget;
 
 public abstract class AndroidBuckRuleComposer extends JvmBuckRuleComposer {
@@ -33,19 +31,7 @@ public abstract class AndroidBuckRuleComposer extends JvmBuckRuleComposer {
   }
 
   static String binManifest(AndroidTarget target) {
-    return "manifest_" + getManifestTargetSuffix(target) + target.getName();
-  }
-
-  private static String getManifestTargetSuffix(AndroidTarget target) {
-    if (target instanceof AndroidAppInstrumentationTarget) {
-      return "test_";
-    } else if (target instanceof AndroidLibInstrumentationTarget) {
-      return "libtest_";
-    } else if (target instanceof AndroidAppTarget) {
-      return "bin_";
-    } else {
-      throw new IllegalStateException();
-    }
+    return "manifest_bin_" + target.getName();
   }
 
   public static String keystore(AndroidTarget target) {

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidBuckRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidBuckRuleComposer.java
@@ -1,7 +1,9 @@
 package com.uber.okbuck.composer.android;
 
 import com.uber.okbuck.composer.jvm.JvmBuckRuleComposer;
+import com.uber.okbuck.core.model.android.AndroidAppInstrumentationTarget;
 import com.uber.okbuck.core.model.android.AndroidAppTarget;
+import com.uber.okbuck.core.model.android.AndroidLibInstrumentationTarget;
 import com.uber.okbuck.core.model.android.AndroidTarget;
 
 public abstract class AndroidBuckRuleComposer extends JvmBuckRuleComposer {
@@ -26,8 +28,24 @@ public abstract class AndroidBuckRuleComposer extends JvmBuckRuleComposer {
     return target.getName() + "_" + aidlDir.replaceAll("[/-]", "_") + "_aidls";
   }
 
-  public static String manifest(AndroidTarget target) {
-    return "manifest_" + target.getName();
+  static String libManifest(AndroidTarget target) {
+    return "manifest_lib_" + target.getName();
+  }
+
+  static String binManifest(AndroidTarget target) {
+    return "manifest_" + getManifestTargetSuffix(target) + target.getName();
+  }
+
+  private static String getManifestTargetSuffix(AndroidTarget target) {
+    if (target instanceof AndroidAppInstrumentationTarget) {
+      return "test_";
+    } else if (target instanceof AndroidLibInstrumentationTarget) {
+      return "libtest_";
+    } else if (target instanceof AndroidAppTarget) {
+      return "bin_";
+    } else {
+      throw new IllegalStateException();
+    }
   }
 
   public static String keystore(AndroidTarget target) {

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidResourceRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidResourceRuleComposer.java
@@ -31,7 +31,7 @@ public final class AndroidResourceRuleComposer extends AndroidBuckRuleComposer {
         .pkg(target.getPackage())
         .res(target.getResDirs())
         .assets(target.getAssetDirs())
-        .resourceUnion(target.getOkbuck().resourceUnion)
+        .resourceUnion(target.getOkbuck().resourceUnionPackage != null)
         .defaultVisibility()
         .ruleType(RuleType.ANDROID_RESOURCE.getBuckName())
         .deps(resDeps)

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/ManifestRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/ManifestRuleComposer.java
@@ -10,16 +10,22 @@ public final class ManifestRuleComposer extends AndroidBuckRuleComposer {
     // no instance
   }
 
-  public static Rule compose(AndroidTarget target) {
+  public static Rule composeForLibrary(AndroidTarget target) {
+    return compose(target).pkg(target.getPackage()).name(libManifest(target));
+  }
+
+  public static Rule composeForBinary(AndroidTarget target) {
+    return compose(target).pkg(target.getApplicationPackage()).name(binManifest(target));
+  }
+
+  private static ManifestRule compose(AndroidTarget target) {
     return new ManifestRule()
         .debuggable(target.getDebuggable())
         .minSdk(target.getMinSdk())
         .targetSdk(target.getTargetSdk())
         .versionCode(target.getVersionCode())
         .versionName(target.getVersionName())
-        .applicationPackage(target.getApplicationPackage())
         .mainManifest(target.getMainManifest())
-        .secondaryManifests(target.getSecondaryManifests())
-        .name(manifest(target));
+        .secondaryManifests(target.getSecondaryManifests());
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidTarget.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidTarget.java
@@ -109,6 +109,8 @@ public abstract class AndroidTarget extends JvmTarget {
     lintExclude = getProp(getOkbuck().lintExclude, ImmutableList.of()).contains(name);
     testExclude = getProp(getOkbuck().testExclude, ImmutableList.of()).contains(name);
 
+    packageName = getOkbuck().resourceUnionPackage;
+
     @Var boolean hasKotlinExtension;
     try {
       AndroidExtensionsExtension androidExtensions =
@@ -360,6 +362,8 @@ public abstract class AndroidTarget extends JvmTarget {
   public String getPackage() {
     if (packageName == null) {
       ensureManifest();
+      Document manifestXml = XmlUtil.loadXml(getProject().file(mainManifest));
+      packageName = manifestXml.getDocumentElement().getAttribute("package").trim();
     }
 
     return packageName;
@@ -397,9 +401,6 @@ public abstract class AndroidTarget extends JvmTarget {
 
     secondaryManifests = new ArrayList<>(manifests);
     mainManifest = secondaryManifests.remove(0);
-
-    Document manifestXml = XmlUtil.loadXml(getProject().file(mainManifest));
-    packageName = manifestXml.getDocumentElement().getAttribute("package").trim();
   }
 
   static List<String> getJavaCompilerOptions(BaseVariant baseVariant) {

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.Input;
@@ -54,7 +55,7 @@ public class OkBuckExtension {
   @Input public Set<File> extraDefs = new HashSet<>();
 
   /** Set to use buck's resource_union behavior */
-  @Input public String resourceUnionPackage;
+  @Nullable @Input public String resourceUnionPackage;
 
   /** Whether to generate android_build_config rules for library projects */
   @Input public boolean libraryBuildConfig = true;

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
@@ -53,8 +53,8 @@ public class OkBuckExtension {
   /** Extra buck defs */
   @Input public Set<File> extraDefs = new HashSet<>();
 
-  /** Whether to turn on buck's resource_union to reflect gradle's resource merging behavior */
-  @Input public boolean resourceUnion = true;
+  /** Set to use buck's resource_union behavior */
+  @Input public String resourceUnionPackage;
 
   /** Whether to generate android_build_config rules for library projects */
   @Input public boolean libraryBuildConfig = true;

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/android/ManifestRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/android/ManifestRule.rocker.raw
@@ -16,8 +16,6 @@ okbuck_manifest(
     target_sdk = '@targetSdk',
 @if (valid(pkg)) {
     package = '@pkg',
-} else {
-    package = '',
 }
 @if (valid(versionCode)) {
     version_code = '@versionCode',

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/android/ManifestRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/android/ManifestRule.rocker.raw
@@ -3,9 +3,9 @@
 String mainManifest,
 String minSdk,
 String targetSdk,
+String pkg,
 Integer versionCode,
 String versionName,
-String applicationPackage,
 boolean debuggable,
 Collection secondaryManifests
 )
@@ -14,14 +14,16 @@ okbuck_manifest(
     main_manifest = '@mainManifest',
     min_sdk = '@minSdk',
     target_sdk = '@targetSdk',
+@if (valid(pkg)) {
+    package = '@pkg',
+} else {
+    package = '',
+}
 @if (valid(versionCode)) {
     version_code = '@versionCode',
 }
 @if (valid(versionName)) {
     version_name = '@versionName',
-}
-@if (valid(applicationPackage)) {
-    application_id = '@applicationPackage',
 }
     debuggable = '@debuggable',
 @if (valid(secondaryManifests)) {

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckDefs.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckDefs.rocker.raw
@@ -135,7 +135,7 @@ def okbuck_manifest(
         main_manifest,
         min_sdk,
         target_sdk,
-        package,
+        package=None,
         version_code=None,
         version_name=None,
         debuggable=False,
@@ -151,7 +151,8 @@ def okbuck_manifest(
         cmds.append("--overlays {}".format(" ".join(["$SRCDIR/" + m for m in secondary_manifests])))
     cmds.append("--property MIN_SDK_VERSION={}".format(min_sdk))
     cmds.append("--property TARGET_SDK_VERSION={}".format(target_sdk))
-    cmds.append("--property PACKAGE={}".format(package))
+    if package:
+      cmds.append("--property PACKAGE={}".format(package))
     if version_code:
       cmds.append("--property VERSION_CODE={}".format(version_code))
     if version_name:

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckDefs.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckDefs.rocker.raw
@@ -135,12 +135,15 @@ def okbuck_manifest(
         main_manifest,
         min_sdk,
         target_sdk,
+        package,
         version_code=None,
         version_name=None,
-        application_id=None,
         debuggable=False,
-        secondary_manifests=[],
+        secondary_manifests=None,
     ):
+    if not secondary_manifests:
+        secondary_manifests = []
+
     cmds =[]
     cmds.append("java -jar -Xmx256m $(location //.okbuck/workspace/manifest-merger:okbuck_manifest_merger)")
     cmds.append("--main $SRCDIR/{}".format(main_manifest))
@@ -148,12 +151,11 @@ def okbuck_manifest(
         cmds.append("--overlays {}".format(" ".join(["$SRCDIR/" + m for m in secondary_manifests])))
     cmds.append("--property MIN_SDK_VERSION={}".format(min_sdk))
     cmds.append("--property TARGET_SDK_VERSION={}".format(target_sdk))
+    cmds.append("--property PACKAGE={}".format(package))
     if version_code:
       cmds.append("--property VERSION_CODE={}".format(version_code))
     if version_name:
       cmds.append("--property VERSION_NAME={}".format(version_name))
-    if application_id:
-      cmds.append("--property PACKAGE={}".format(application_id))
     if debuggable:
           cmds.append("--debuggable true")
     cmds.append("--out $OUT")
@@ -176,14 +178,24 @@ def isLintEnabled(manifest):
 def okbuck_android_library(
     name,
     manifest=None,
-    deps=[],
-    lint_src_dirs=[],
-    lint_resource_dirs=[],
+    deps=None,
+    lint_src_dirs=None,
+    lint_resource_dirs=None,
     disable_lint = False,
-    custom_lints=[],
-    lint_options=[],
+    custom_lints=None,
+    lint_options=None,
     **kwargs
     ):
+    if not deps:
+        deps = []
+    if not lint_src_dirs:
+        lint_src_dirs = []
+    if not lint_resource_dirs:
+        lint_resource_dirs = []
+    if not custom_lints:
+        custom_lints = []
+    if not lint_options:
+        lint_options = []
 
     android_library(
         name = name,


### PR DESCRIPTION
**Description**:
- Change `resourceUnion` extension option to `resourceUnionPackage`
- Use resource union package when available for library manifests (IDE support etc.)
- Make sure binaries still use the final application id
- Cleanup some okbuck defs