### PR TITLE
Set debuggable to boolean instead of string for it to be computed correctly.

### DIFF
--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/android/ManifestRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/android/ManifestRule.rocker.raw
@@ -23,7 +23,11 @@ okbuck_manifest(
 @if (valid(versionName)) {
     version_name = '@versionName',
 }
-    debuggable = '@debuggable',
+@if (debuggable) {
+    debuggable = True,
+} else {
+    debuggable = False,
+}
 @if (valid(secondaryManifests)) {
     secondary_manifests = [
     @for (secondaryManifest : secondaryManifests) {

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckDefs.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckDefs.rocker.raw
@@ -152,13 +152,15 @@ def okbuck_manifest(
     cmds.append("--property MIN_SDK_VERSION={}".format(min_sdk))
     cmds.append("--property TARGET_SDK_VERSION={}".format(target_sdk))
     if package:
-      cmds.append("--property PACKAGE={}".format(package))
+        cmds.append("--property PACKAGE={}".format(package))
     if version_code:
-      cmds.append("--property VERSION_CODE={}".format(version_code))
+        cmds.append("--property VERSION_CODE={}".format(version_code))
     if version_name:
-      cmds.append("--property VERSION_NAME={}".format(version_name))
+        cmds.append("--property VERSION_NAME={}".format(version_name))
     if debuggable:
-          cmds.append("--debuggable true")
+        cmds.append("--debuggable true")
+    else:
+        cmds.append("--debuggable false")
     cmds.append("--out $OUT")
 
     genrule(


### PR DESCRIPTION
- `--debuggable false` is being passed correctly which was always `true` since it was a string. 

Before:
```
okbuck_manifest(
    name = 'manifest_lib_debug',
    main_manifest = 'src/main/AndroidManifest.xml',
    min_sdk = '24',
    target_sdk = '27',
    package = 'com.uber',
    version_code = '1',
    version_name = '0.2.0',
    debuggable = ‘false’,
)
```

After:
```
okbuck_manifest(
    name = 'manifest_lib_debug',
    main_manifest = 'src/main/AndroidManifest.xml',
    min_sdk = '24',
    target_sdk = '27',
    package = 'com.uber',
    version_code = '1',
    version_name = '0.2.0',
    debuggable = False,
)
```

```
  "cmd" : "java -jar -Xmx256m $(location //.okbuck/workspace/manifest-merger:okbuck_manifest_merger) --main $SRCDIR/src/main/AndroidManifest.xml --overlays $SRCDIR/src/release/AndroidManifest.xml --property MIN_SDK_VERSION=15 --property TARGET_SDK_VERSION=27 --property PACKAGE=com.app --property VERSION_CODE=1 --property VERSION_NAME=0.0.1 --debuggable false --out $OUT",
```

<!--
Thank you for contributing to okbuck. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:
