### PR TITLE
Fix manifest-merger --overlays

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.uber.okbuck.example">
+    <!-- This manifest is used as an integration test for manifest merger. -->
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+</manifest>

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckDefs.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckDefs.rocker.raw
@@ -148,7 +148,8 @@ def okbuck_manifest(
     cmds.append("java -jar -Xmx256m $(location //.okbuck/workspace/manifest-merger:okbuck_manifest_merger)")
     cmds.append("--main $SRCDIR/{}".format(main_manifest))
     if len(secondary_manifests) > 0:
-        cmds.append("--overlays {}".format(" ".join(["$SRCDIR/" + m for m in secondary_manifests])))
+        for secondary_manifest in secondary_manifests:
+            cmds.append("--overlays {}".format("$SRCDIR/" + secondary_manifest))
     cmds.append("--property MIN_SDK_VERSION={}".format(min_sdk))
     cmds.append("--property TARGET_SDK_VERSION={}".format(target_sdk))
     if package:


### PR DESCRIPTION
This fixes following error thrown at Buck build time if multiple values were passed after `--overlays` option:

```console
Build failed: Command failed with exit code 1.
stderr: Error: Command switch /Users/user/projects/project/buck-out/gen/project/manifest_lib_devDebug/AndroidManifest.xml has no value associated

    When running <(cd buck-out/gen/project/manifest_lib_devDebug__srcs && OUT=/Users/user/projects/project/buck-out/gen/project/manifest_lib_devDebug/AndroidManifest.xml SRCDIR=/Users/user/projects/project/buck-out/gen/project/manifest_lib_devDebug__srcs /bin/bash -e /Users/user/projects/project/buck-out/tmp/genrule-1107998254956004441.sh)>.
    When building rule //project/manifest_lib_devDebug.
```

[ManifestMergerCli is capable](https://github.com/uber/okbuck/blob/v0.43.0/manifest-merger-cli/src/main/java/com/uber/okbuck/manifmerger/ManifestMergerCli.java#L107) of adding arbitrary amount of overlay manifests if they're passed separately, each with `--overlays`.

This PR passes each overlay manifest with its own `--overlays` option.