### PR TITLE
Added option to okBuck to configure rule overrides compatible with skylark

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/OkBuckGradlePlugin.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/OkBuckGradlePlugin.java
@@ -271,8 +271,7 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
                   bp -> {
                     bp.getConfigurations().maybeCreate(BUCK_LINT);
                     Task okbuckProjectTask = bp.getTasks().maybeCreate(OKBUCK);
-                    okbuckProjectTask.doLast(
-                        task -> BuckFileGenerator.generate(bp, okbuckExt.getVisibilityExtension()));
+                    okbuckProjectTask.doLast(task -> BuckFileGenerator.generate(bp, okbuckExt));
                     okbuckProjectTask.dependsOn(setupOkbuck);
                     okBuckClean.dependsOn(okbuckProjectTask);
                   });

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
@@ -98,12 +98,14 @@ public class OkBuckExtension {
   private LintExtension lintExtension;
   private ExternalDependenciesExtension externalDependenciesExtension;
   private VisibilityExtension visibilityExtension = new VisibilityExtension();
+  private RuleOverridesExtension ruleOverridesExtension;
 
   public OkBuckExtension(Project project) {
     buckProjects = project.getSubprojects();
     kotlinExtension = new KotlinExtension(project);
     lintExtension = new LintExtension(project);
     externalDependenciesExtension = new ExternalDependenciesExtension(project);
+    ruleOverridesExtension = new RuleOverridesExtension(project);
   }
 
   public void wrapper(Action<WrapperExtension> container) {
@@ -184,5 +186,13 @@ public class OkBuckExtension {
 
   public VisibilityExtension getVisibilityExtension() {
     return visibilityExtension;
+  }
+
+  public void ruleOverrides(Action<RuleOverridesExtension> container) {
+    container.execute(ruleOverridesExtension);
+  }
+
+  public RuleOverridesExtension getRuleOverridesExtension() {
+    return ruleOverridesExtension;
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/RuleOverridesExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/RuleOverridesExtension.java
@@ -1,0 +1,150 @@
+package com.uber.okbuck.extension;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import groovy.lang.Closure;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.gradle.api.Project;
+
+/*
+Note: Do not merge this section with javadoc to prevent GJF from butchering it.
+Example:
+
+ruleOverrides {
+    defaultImportLocation = "//tooling/buck-defs:my_targets.bzl"
+    defaultRuleNamePrefix = "my_company_"
+    override {
+        nativeRuleName = "java_library"
+    }
+    override {
+        nativeRuleName = "java_test"
+    }
+    override {
+        nativeRuleName = "java_binary"
+    }
+    override {
+        nativeRuleName = "scala_library"
+        importLocation = "//tooling/buck-defs:experimental.bzl"
+        newRuleName = "experimental_scala_library"
+    }
+    override {
+        nativeRuleName = "scala_test"
+        importLocation = "//tooling/buck-defs:experimental.bzl"
+        newRuleName = "experimental_scala_test"
+    }
+}
+*/
+/**
+ * Custom overrides for rules re-defined within project See example above.
+ *
+ * <p>Note, for some of the rules, okBuck may generate own rule types, for example
+ * "okbuck_android_library". To replace it with own override, please use "android_library" as
+ * nativeRuleName
+ */
+public class RuleOverridesExtension {
+
+  private Map<String, OverrideSetting> overridesMap = Collections.emptyMap();
+  private final List<OverrideSetting> overrides = new ArrayList<>();
+
+  /** Import location to be used by default for overrides. */
+  @Nullable private String defaultImportLocation;
+
+  /** Rule name prefix to be used by default for overrides. */
+  @Nullable private String defaultRuleNamePrefix;
+
+  /** Override section for the rule. */
+  protected void override(Closure<OverrideSetting> action) {
+    OverrideSetting setting = new OverrideSetting();
+    action.setDelegate(setting);
+    action.call(setting);
+    overrides.add(setting);
+  }
+
+  public Map<String, OverrideSetting> getOverrides() {
+    return overridesMap;
+  }
+
+  public RuleOverridesExtension(Project project) {
+    project.afterEvaluate(
+        evaluatedProject -> {
+          validateExtension();
+          overridesMap =
+              overrides
+                  .stream()
+                  .map(RuleOverridesExtension.this::applyDefaults)
+                  .collect(
+                      ImmutableMap.toImmutableMap(
+                          OverrideSetting::getNativeRuleName, Function.identity()));
+        });
+  }
+
+  private OverrideSetting applyDefaults(OverrideSetting originalSetting) {
+    return new OverrideSetting(
+        originalSetting.getNativeRuleName(),
+        Optional.ofNullable(Strings.emptyToNull(originalSetting.getImportLocation()))
+            .orElse(defaultImportLocation),
+        Optional.ofNullable(Strings.emptyToNull(originalSetting.getNewRuleName()))
+            .orElse(defaultRuleNamePrefix + originalSetting.getNativeRuleName()));
+  }
+
+  private void validateExtension() {
+    Set<String> usedOverrideKeys = new HashSet<>();
+    for (OverrideSetting baseSetting : overrides) {
+      OverrideSetting setting = applyDefaults(baseSetting);
+      if (usedOverrideKeys.contains(setting.nativeRuleName)) {
+        throw new IllegalArgumentException(
+            "Multiple overrides specified for the same rule: " + setting.nativeRuleName);
+      } else {
+        usedOverrideKeys.add(setting.nativeRuleName);
+      }
+      Preconditions.checkNotNull(
+          Strings.emptyToNull(setting.nativeRuleName), "nativeRuleName is required for override");
+      Preconditions.checkNotNull(
+          Strings.emptyToNull(setting.importLocation),
+          setting.nativeRuleName
+              + ": importLocation is required for override, since no defaultImportLocation is specified");
+      Preconditions.checkNotNull(
+          Strings.emptyToNull(setting.newRuleName),
+          setting.nativeRuleName
+              + ": newRuleName is required for override, since no defaultRuleNamePrefix is specified");
+    }
+  }
+
+  public static class OverrideSetting {
+    @Nullable private String nativeRuleName;
+    @Nullable private String importLocation;
+    @Nullable private String newRuleName;
+
+    public OverrideSetting() {}
+
+    public OverrideSetting(String nativeRuleName, String importLocation, String newRuleName) {
+      this.nativeRuleName = nativeRuleName;
+      this.importLocation = importLocation;
+      this.newRuleName = newRuleName;
+    }
+
+    @Nullable
+    public String getNativeRuleName() {
+      return nativeRuleName;
+    }
+
+    @Nullable
+    public String getImportLocation() {
+      return importLocation;
+    }
+
+    @Nullable
+    public String getNewRuleName() {
+      return newRuleName;
+    }
+  }
+}

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/core/Rule.java
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/core/Rule.java
@@ -43,6 +43,10 @@ public abstract class Rule<T extends Rule> extends DefaultRockerModel {
     return (T) this;
   }
 
+  public String ruleType() {
+    return ruleType;
+  }
+
   public T deps(Collection deps) {
     this.deps = deps;
     return (T) this;


### PR DESCRIPTION
Now instead of having to define java_library in DEFS one can tell okBuck to load and use my_java_library in //defs/my_defs.bzl like:

```
okbuck {
    ruleOverrides {
        override {
            nativeRuleName = "java_library"
            importLocation = "//defs/my_defs.bzl"
            newRuleName = "my_java_library"
        }
    }
}
```

with this config specified, generates files look like this:

```
load('//defs/my_defs.bzl', 'my_java_library')

my_java_library(
...
```

<!--
Thank you for contributing to okbuck. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:
