### PR TITLE
Gate jetifier only on android.enableJetifier

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/JetifierManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/JetifierManager.java
@@ -55,14 +55,8 @@ public final class JetifierManager {
     }
 
     public static boolean isJetifierEnabled(Project project) {
-        Map<String, ?> properties = project.getProperties();
-
-        if (properties.containsKey("android.useAndroidX")
-                && properties.containsKey("android.enableJetifier")) {
-            return (Boolean.valueOf((String) properties.get("android.useAndroidX")))
-                    && (Boolean.valueOf((String) properties.get("android.enableJetifier")));
-        }
-        return false;
+        Object prop = project.findProperty("android.enableJetifier");
+        return prop != null ? Boolean.valueOf((String) prop) : false;
     }
 
     public void setupJetifier(String version) {


### PR DESCRIPTION
<!--
Thank you for contributing to okbuck. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**: `android.useAndroidX` is meant for code gen tools to generate androidx symbols and is not directly related to jetifier

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**: N/A
