### PR TITLE
Enable jetifier for jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,6 +210,13 @@ okbuck {
         ]
     }
 
+    jetifier {
+        aarOnly = true
+        exclude = [
+            "androidx.*"
+        ]
+    }
+
     externalDependencies {
         versionless = true
         allowLatestVersion = [

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/java/PrebuiltRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/java/PrebuiltRuleComposer.java
@@ -54,6 +54,7 @@ public class PrebuiltRuleComposer extends JvmBuckRuleComposer {
                       .prebuiltType(ruleType.getProperties().get(0))
                       .prebuilt(dependency.getDependencyFileName())
                       .mavenCoords(dependency.getMavenCoords())
+                      .enableJetifier(dependency.enableJetifier())
                       .source(source)
                       .ruleType(ruleType.getBuckName())
                       .name(dependency.getCacheName()));

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyCache.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyCache.java
@@ -5,6 +5,8 @@ import com.uber.okbuck.core.manager.DependencyManager;
 import com.uber.okbuck.core.model.base.Scope;
 import com.uber.okbuck.core.util.ProjectUtil;
 import com.uber.okbuck.extension.ExternalDependenciesExtension;
+import com.uber.okbuck.extension.JetifierExtension;
+import com.uber.okbuck.extension.OkBuckExtension;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -176,14 +178,17 @@ public class DependencyCache {
    * @param configurations The set of configurations to materialize into the dependency cache
    */
   private Set<String> build(Set<Configuration> configurations) {
+    OkBuckExtension okBuckExtension = ProjectUtil.getOkBuckExtension(rootProject);
     ExternalDependenciesExtension externalDependenciesExtension =
-        ProjectUtil.getOkBuckExtension(rootProject).getExternalDependenciesExtension();
+        okBuckExtension.getExternalDependenciesExtension();
+    JetifierExtension jetifierExtension = okBuckExtension.getJetifierExtension();
 
     return configurations
         .stream()
         .map(
             configuration ->
-                DependencyUtils.resolveExternal(configuration, externalDependenciesExtension))
+                DependencyUtils.resolveExternal(
+                    configuration, externalDependenciesExtension, jetifierExtension))
         .flatMap(Collection::stream)
         .map(dependency -> get(dependency, true))
         .map(this::getPath)

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyUtils.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyUtils.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.uber.okbuck.core.util.FileUtil;
 import com.uber.okbuck.extension.ExternalDependenciesExtension;
+import com.uber.okbuck.extension.JetifierExtension;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystem;
@@ -135,7 +136,9 @@ public final class DependencyUtils {
   }
 
   public static Set<ExternalDependency> resolveExternal(
-      Configuration configuration, ExternalDependenciesExtension extension) {
+      Configuration configuration,
+      ExternalDependenciesExtension externalDependenciesExtension,
+      JetifierExtension jetifierExtension) {
     try {
       return configuration
           .getIncoming()
@@ -158,9 +161,11 @@ public final class DependencyUtils {
                       moduleIdentifier.getModule(),
                       moduleIdentifier.getVersion(),
                       artifact.getFile(),
-                      extension);
+                      externalDependenciesExtension,
+                      jetifierExtension);
                 } else {
-                  return ExternalDependency.fromLocal(artifact.getFile(), extension);
+                  return ExternalDependency.fromLocal(
+                      artifact.getFile(), externalDependenciesExtension, jetifierExtension);
                 }
               })
           .filter(Objects::nonNull)

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/base/Scope.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/base/Scope.java
@@ -12,6 +12,8 @@ import com.uber.okbuck.core.dependency.ExternalDependency;
 import com.uber.okbuck.core.dependency.VersionlessDependency;
 import com.uber.okbuck.core.util.FileUtil;
 import com.uber.okbuck.core.util.ProjectUtil;
+import com.uber.okbuck.extension.ExternalDependenciesExtension;
+import com.uber.okbuck.extension.JetifierExtension;
 import com.uber.okbuck.extension.OkBuckExtension;
 import java.io.File;
 import java.io.IOException;
@@ -321,6 +323,11 @@ public class Scope {
     Set<ResolvedArtifactResult> aarOrJarartifacts =
         getArtifacts(configuration, EXTERNAL_DEP_FILTER, ImmutableList.of("aar", "jar"));
 
+    OkBuckExtension okBuckExtension = ProjectUtil.getOkBuckExtension(project);
+    ExternalDependenciesExtension externalDependenciesExtension =
+        okBuckExtension.getExternalDependenciesExtension();
+    JetifierExtension jetifierExtension = okBuckExtension.getJetifierExtension();
+
     aarOrJarartifacts.forEach(
         artifact -> {
           if (!DependencyUtils.isConsumable(artifact.getFile())) {
@@ -340,7 +347,8 @@ public class Scope {
                     moduleIdentifier.getModule(),
                     moduleIdentifier.getVersion(),
                     artifact.getFile(),
-                    ProjectUtil.getOkBuckExtension(project).getExternalDependenciesExtension());
+                    externalDependenciesExtension,
+                    jetifierExtension);
             external.add(externalDependency);
           } else {
             String rootProjectPath = project.getRootProject().getProjectDir().getAbsolutePath();
@@ -359,8 +367,7 @@ public class Scope {
               }
               external.add(
                   ExternalDependency.fromLocal(
-                      artifact.getFile(),
-                      ProjectUtil.getOkBuckExtension(project).getExternalDependenciesExtension()));
+                      artifact.getFile(), externalDependenciesExtension, jetifierExtension));
 
             } catch (IOException e) {
               throw new RuntimeException(e);

--- a/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
@@ -144,7 +144,6 @@ public class OkBuckTask extends DefaultTask {
         .classpathMacro(CLASSPATH_ABI_MACRO)
         .lintJvmArgs(okbuckExt.getLintExtension().jvmArgs)
         .enableLint(!okbuckExt.getLintExtension().disabled)
-        .enableJetifier(JetifierManager.isJetifierEnabled(getProject().getRootProject()))
         .externalDependencyCache(okbuckExt.externalDependencyCache)
         .classpathExclusionRegex(okbuckExt.getLintExtension().classpathExclusionRegex)
         .useCompilationClasspath(okbuckExt.getLintExtension().useCompilationClasspath)

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/ProguardUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/ProguardUtil.java
@@ -59,7 +59,8 @@ public final class ProguardUtil {
                 PROGUARD_MODULE,
                 proguardVersion,
                 artifactResult.get().getFile(),
-                ProjectUtil.getOkBuckExtension(project).getExternalDependenciesExtension());
+                ProjectUtil.getOkBuckExtension(project).getExternalDependenciesExtension(),
+                ProjectUtil.getOkBuckExtension(project).getJetifierExtension());
 
         return Paths.get(proguardCache.getPath(proguardCache.get(dependency, true)))
             .getParent()

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/JetifierExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/JetifierExtension.java
@@ -1,13 +1,72 @@
 package com.uber.okbuck.extension;
 
+import com.google.common.collect.ImmutableSet;
+import com.uber.okbuck.core.dependency.ExternalDependency;
+import com.uber.okbuck.core.manager.JetifierManager;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.gradle.api.Project;
+
 public class JetifierExtension {
 
   public static final String DEFAULT_JETIFIER_VERSION = "1.0.0-beta02";
+  private static final List<String> BLACKLISTED_DEPS =
+      Arrays.asList(
+          "com.android.tools.build.jetifier:jetifier-core",
+          "com.android.tools.build.jetifier:jetifier-processor",
+          "com.google.code.gson:gson",
+          "commons-cli:commons-cli",
+          "org.jdom:jdom2",
+          "org.jetbrains:annotations",
+          "org.ow2.asm:asm-commons",
+          "org.ow2.asm:asm-tree",
+          "org.ow2.asm:asm-util",
+          "org.ow2.asm:asm",
+          "org.jetbrains.kotlin:.*");
 
   /** Jetifier jar version */
   public String version;
 
-  JetifierExtension() {
+  /** Enable jetify to act on aars only */
+  private boolean aarOnly;
+
+  /** Stores the dependencies which are excluded from being jetified. */
+  private List<String> exclude = new ArrayList<>();
+
+  private final boolean enableJetifier;
+
+  @Nullable private List<Pattern> excludePatterns;
+
+  JetifierExtension(Project project) {
     version = DEFAULT_JETIFIER_VERSION;
+    enableJetifier = JetifierManager.isJetifierEnabled(project);
+  }
+
+  private List<Pattern> getExcludePatterns() {
+    if (excludePatterns == null) {
+      excludePatterns =
+          new ImmutableSet.Builder<String>()
+              .addAll(exclude)
+              .addAll(BLACKLISTED_DEPS)
+              .build()
+              .stream()
+              .map(Pattern::compile)
+              .collect(Collectors.toList());
+    }
+    return excludePatterns;
+  }
+
+  public boolean shouldJetify(String group, String name, String packaging) {
+    if (aarOnly && packaging.equals(ExternalDependency.JAR)) {
+      return false;
+    }
+    return enableJetifier
+        && getExcludePatterns()
+            .stream()
+            .noneMatch(pattern -> pattern.matcher(group + ":" + name).matches());
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/JetifierExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/JetifierExtension.java
@@ -60,6 +60,14 @@ public class JetifierExtension {
     return excludePatterns;
   }
 
+  /**
+   * Check if this dependency, described by the params, should be jetified, that is, run
+   * jetifier on it before prebuilding it.
+   * @param group - Dependency group
+   * @param name - Dependency name
+   * @param packaging - Packaging type (aar\jar)
+   * @return true if shouldJetify, false otherwise
+   */
   public boolean shouldJetify(String group, String name, String packaging) {
     if (aarOnly && packaging.equals(ExternalDependency.JAR)) {
       return false;

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
@@ -105,7 +105,7 @@ public class OkBuckExtension {
     buckProjects = project.getSubprojects();
     kotlinExtension = new KotlinExtension(project);
     lintExtension = new LintExtension(project);
-    jetifierExtension = new JetifierExtension();
+    jetifierExtension = new JetifierExtension(project);
     externalDependenciesExtension = new ExternalDependenciesExtension(project);
     ruleOverridesExtension = new RuleOverridesExtension(project);
   }

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/RuleOverridesExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/RuleOverridesExtension.java
@@ -60,6 +60,7 @@ public class RuleOverridesExtension {
   private static final ImmutableList<RuleType> OKBUCK_DEFINED_RULES =
       ImmutableList.of(
           RuleType.AIDL,
+          RuleType.PREBUILT_JAR,
           RuleType.ANDROID_LIBRARY,
           RuleType.ANDROID_PREBUILT_AAR,
           RuleType.KOTLIN_ANDROID_LIBRARY,

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckDefs.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckDefs.rocker.raw
@@ -5,7 +5,6 @@ String classpathMacro,
 String lintJvmArgs,
 String externalDependencyCache,
 boolean enableLint,
-boolean enableJetifier,
 boolean useCompilationClasspath,
 String classpathExclusionRegex
 )
@@ -319,25 +318,47 @@ def okbuck_keystore(
 def okbuck_android_prebuilt_aar(
     name,
     aar,
+    enable_jetifier=False,
     **kwargs
     ):
-@if(enableJetifier) {
-    jetified = name.replace('.aar', '-jetified.aar')
-    genname = "unjetified_" + name
-    native.genrule(
-        name = genname,
-        srcs = [aar],
-        out = jetified,
-        cmd = "$(exe //.okbuck/workspace/jetifier:okbuck_jetifier) -i $SRCS -o $OUT"
-    )
-}
+    aar_path = aar
+    if enable_jetifier:
+        jetified = name.replace('.aar', '-jetified.aar')
+        genname = "unjetified_" + name
+        aar_path =  ":{}".format(genname)
+        native.genrule(
+            name = genname,
+            srcs = [aar],
+            out = jetified,
+            cmd = "$(exe //.okbuck/workspace/jetifier:okbuck_jetifier) -i $SRCS -o $OUT"
+        )
 
     native.android_prebuilt_aar(
         name = name,
-@if(enableJetifier) {
-        aar = ":{}".format(genname),
-} else {
-        aar = aar,
-}
+        aar = aar_path,
+        **kwargs
+    )
+
+def okbuck_prebuilt_jar(
+    name,
+    binary_jar,
+    enable_jetifier=False,
+    **kwargs
+    ):
+    jar_path = binary_jar
+    if enable_jetifier:
+        jetified = name.replace('.jar', '-jetified.jar')
+        genname = "unjetified_" + name
+        jar_path =  ":{}".format(genname)
+        native.genrule(
+            name = genname,
+            srcs = [binary_jar],
+            out = jetified,
+            cmd = "$(exe //.okbuck/workspace/jetifier:okbuck_jetifier) -i $SRCS -o $OUT"
+        )
+
+    native.prebuilt_jar(
+        name = name,
+        binary_jar = binary_jar,
         **kwargs
     )

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/java/Prebuilt.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/java/Prebuilt.rocker.raw
@@ -2,7 +2,8 @@
 String prebuiltType,
 String prebuilt,
 String source,
-String mavenCoords
+String mavenCoords,
+boolean enableJetifier,
 )
 @(ruleType)(
     name = '@name',
@@ -12,6 +13,9 @@ String mavenCoords
 }
 @if (valid(mavenCoords)) {
     maven_coords = '@mavenCoords',
+}
+@if (enableJetifier) {
+    enable_jetifier = True,
 }
     visibility = ['PUBLIC'],
 )


### PR DESCRIPTION
Some jars also depends on old android support packages. So running jetifier on jars is also an important step to fully provide support for jetifier and androidX.

In order to provide that, while still being able to have performatic builds, the need to run jetifier is now calculated per dependency, and not settled entirely for a given packaging type (as it was with aars before)

Main changes, then, are:
* Enable jetifier is now calculated per dependency
* Make generated defs clearer for when jetifier is not enabled in project
* Jetifier by default will be enabled only for all types of external dependencies (jars and aars) packagings. But one can optOut (from jars) by configuring `aarOnly` on the jetifier extension
* It's now also possible, for both jars and aars, to provide a list of regexes of dependencies to exclude from being jetified.