### PR TITLE
Cache scope as an extra property to project instead of keeping it on the plugin object.

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
@@ -12,7 +12,6 @@ import com.uber.okbuck.core.manager.LintManager;
 import com.uber.okbuck.core.manager.ScalaManager;
 import com.uber.okbuck.core.manager.TransformManager;
 import com.uber.okbuck.core.model.base.ProjectType;
-import com.uber.okbuck.core.model.base.Scope;
 import com.uber.okbuck.core.model.base.Target;
 import com.uber.okbuck.core.model.base.TargetCache;
 import com.uber.okbuck.extension.OkBuckExtension;
@@ -97,10 +96,6 @@ public final class ProjectUtil {
   @Nullable
   public static Target getTargetForVariant(Project targetProject, @Nullable String variant) {
     return getTargetCache(targetProject).getTargetForVariant(targetProject, variant);
-  }
-
-  public static Map<Project, Map<String, Scope>> getScopes(Project project) {
-    return getPlugin(project).scopes;
   }
 
   public static OkBuckGradlePlugin getPlugin(Project project) {


### PR DESCRIPTION
Scope cache is only required during the lifecycle of the okbuck task. 

Running `jcmd <pid> GC.run` on the process lowers down the memory footprint significantly which was not happening before. 