### PR TITLE
Cache TargetCache as an extra property of the project instead of OkBuckGradlePlugin

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -101,7 +101,6 @@ task sourcesJar(type: Jar) {
 }
 
 def publishVersion = "0.45.2"
-
 group = "com.uber"
 version = publishVersion
 def siteUrl = "https://github.com/uber/okbuck"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -101,6 +101,7 @@ task sourcesJar(type: Jar) {
 }
 
 def publishVersion = "0.45.2"
+
 group = "com.uber"
 version = publishVersion
 def siteUrl = "https://github.com/uber/okbuck"

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/LintManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/LintManager.java
@@ -39,6 +39,7 @@ public final class LintManager {
   private final BuckFileManager buckFileManager;
 
   private Set<String> dependencies;
+  private DependencyCache lintDepCache;
 
   @SuppressWarnings("NullAway")
   public LintManager(Project project, String lintBuckFile, BuckFileManager buckFileManager) {
@@ -74,16 +75,14 @@ public final class LintManager {
   }
 
   public DependencyCache getLintDepsCache() {
-    OkBuckGradlePlugin okBuckGradlePlugin = ProjectUtil.getPlugin(project);
-    if (okBuckGradlePlugin.lintDepCache == null) {
-      okBuckGradlePlugin.lintDepCache =
-          new DependencyCache(project, ProjectUtil.getDependencyManager(project));
+    if (lintDepCache == null) {
+      lintDepCache = new DependencyCache(project, ProjectUtil.getDependencyManager(project));
 
       dependencies =
-          okBuckGradlePlugin.lintDepCache.build(
+          lintDepCache.build(
               project.getRootProject().getConfigurations().getByName(LINT_DEPS_CONFIG));
     }
-    return okBuckGradlePlugin.lintDepCache;
+    return lintDepCache;
   }
 
   public void finalizeDependencies() {

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/base/TargetCache.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/base/TargetCache.java
@@ -3,90 +3,91 @@ package com.uber.okbuck.core.model.base;
 import com.android.build.gradle.AppExtension;
 import com.android.build.gradle.LibraryExtension;
 import com.android.build.gradle.api.BaseVariant;
+import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.Var;
 import com.uber.okbuck.core.model.android.AndroidAppTarget;
 import com.uber.okbuck.core.model.android.AndroidLibTarget;
 import com.uber.okbuck.core.model.jvm.JvmTarget;
 import com.uber.okbuck.core.util.ProjectUtil;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.gradle.api.Project;
 
-public class TargetCache {
+public final class TargetCache {
 
-  private final Map<Project, Map<String, Target>> store = new HashMap<>();
-  private final Map<Project, Map<String, Target>> artifactNameToTarget = new HashMap<>();
+  private final Project project;
 
-  public Map<String, Target> getTargets(Project project) {
-    @Var Map<String, Target> projectTargets = store.get(project);
-    if (projectTargets == null) {
+  @Nullable private Map<String, Target> targets;
+
+  public TargetCache(Project project) {
+    this.project = project;
+  }
+
+  public synchronized Map<String, Target> getTargets() {
+    if (targets == null) {
       ProjectType type = ProjectUtil.getType(project);
       switch (type) {
         case ANDROID_APP:
-          projectTargets = new HashMap<>();
-          for (BaseVariant v :
-              project.getExtensions().getByType(AppExtension.class).getApplicationVariants()) {
-            projectTargets.put(v.getName(), new AndroidAppTarget(project, v.getName()));
-          }
+          targets =
+              project
+                  .getExtensions()
+                  .getByType(AppExtension.class)
+                  .getApplicationVariants()
+                  .stream()
+                  .collect(
+                      ImmutableMap.toImmutableMap(
+                          BaseVariant::getName, v -> new AndroidAppTarget(project, v.getName())));
           break;
         case ANDROID_LIB:
-          projectTargets = new HashMap<>();
-          Map<String, Target> projectArtifacts = new HashMap<>();
-          for (BaseVariant v :
-              project.getExtensions().getByType(LibraryExtension.class).getLibraryVariants()) {
-            Target target = new AndroidLibTarget(project, v.getName());
-            projectTargets.put(v.getName(), target);
-
-            projectArtifacts.put(v.getName(), target);
-          }
-          artifactNameToTarget.put(project, projectArtifacts);
+          targets =
+              project
+                  .getExtensions()
+                  .getByType(LibraryExtension.class)
+                  .getLibraryVariants()
+                  .stream()
+                  .collect(
+                      ImmutableMap.toImmutableMap(
+                          BaseVariant::getName, v -> new AndroidLibTarget(project, v.getName())));
           break;
         case KOTLIN_LIB:
-          projectTargets =
-              Collections.singletonMap(
+          targets =
+              ImmutableMap.of(
                   JvmTarget.MAIN, new JvmTarget(project, JvmTarget.MAIN, "kapt", "kaptTest"));
           break;
         case GROOVY_LIB:
         case SCALA_LIB:
         case JAVA_LIB:
-          projectTargets =
-              Collections.singletonMap(JvmTarget.MAIN, new JvmTarget(project, JvmTarget.MAIN));
+          targets = ImmutableMap.of(JvmTarget.MAIN, new JvmTarget(project, JvmTarget.MAIN));
           break;
         default:
-          projectTargets = Collections.emptyMap();
+          targets = ImmutableMap.of();
           break;
       }
-      store.put(project, projectTargets);
     }
 
-    return projectTargets;
+    return targets;
   }
 
   @Nullable
-  public Target getTargetForVariant(Project targetProject, @Nullable String variant) {
+  Target getTargetForVariant(@Nullable String variant) {
     @Var Target result = null;
-    ProjectType type = ProjectUtil.getType(targetProject);
+    ProjectType type = ProjectUtil.getType(project);
     switch (type) {
       case ANDROID_LIB:
-        Map<String, Target> targetMap = artifactNameToTarget.get(targetProject);
-        if (targetMap != null) {
-          result = targetMap.get(variant);
-        }
+        result = getTargets().get(variant);
         if (result == null) {
           throw new IllegalStateException(
-              "No target found for " + targetProject.getDisplayName() + " for variant " + variant);
+              "No target found for " + project.getDisplayName() + " for variant " + variant);
         }
         break;
       case GROOVY_LIB:
       case JAVA_LIB:
       case KOTLIN_LIB:
       case SCALA_LIB:
-        result = getTargets(targetProject).values().iterator().next();
+        result = getTargets().values().iterator().next();
         break;
       default:
-        result = null;
+        break;
     }
     return result;
   }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectCache.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectCache.java
@@ -1,0 +1,73 @@
+package com.uber.okbuck.core.util;
+
+import com.uber.okbuck.core.model.base.Scope;
+import com.uber.okbuck.core.model.base.TargetCache;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.gradle.api.Project;
+
+public class ProjectCache {
+
+  private static final String SCOPE_CACHE = "okbuckScopeCache";
+  private static final String TARGET_CACHE = "okbuckTargetCache";
+
+  private ProjectCache() {}
+
+  public static Map<String, Scope> getScopeCache(Project project) {
+    String scopeCacheKey = getCacheKey(project, SCOPE_CACHE);
+
+    Map<String, Scope> scopeCache = (Map<String, Scope>) project.property(scopeCacheKey);
+    if (scopeCache == null) {
+      throw new RuntimeException(
+          "Scope cache external property '" + scopeCacheKey + "' is not set.");
+    }
+    return scopeCache;
+  }
+
+  public static TargetCache getTargetCache(Project project) {
+    String targetCacheKey = getCacheKey(project, TARGET_CACHE);
+
+    TargetCache targetCache = (TargetCache) project.property(targetCacheKey);
+    if (targetCache == null) {
+      throw new RuntimeException(
+          "Target cache external property '" + targetCacheKey + "' is not set.");
+    }
+    return targetCache;
+  }
+
+  public static void initScopeCache(Project project) {
+    project
+        .getExtensions()
+        .getExtraProperties()
+        .set(getCacheKey(project, SCOPE_CACHE), new ConcurrentHashMap<>());
+  }
+
+  public static void resetScopeCache(Project project) {
+    project.getExtensions().getExtraProperties().set(getCacheKey(project, SCOPE_CACHE), null);
+  }
+
+  public static void initTargetCacheForAll(Project project) {
+    initTargetCache(project);
+    project.getSubprojects().forEach(ProjectCache::initTargetCache);
+  }
+
+  public static void resetTargetCacheForAll(Project project) {
+    resetTargetCache(project);
+    project.getSubprojects().forEach(ProjectCache::resetTargetCache);
+  }
+
+  private static void initTargetCache(Project project) {
+    project
+        .getExtensions()
+        .getExtraProperties()
+        .set(getCacheKey(project, TARGET_CACHE), new TargetCache(project));
+  }
+
+  private static void resetTargetCache(Project project) {
+    project.getExtensions().getExtraProperties().set(getCacheKey(project, TARGET_CACHE), null);
+  }
+
+  private static String getCacheKey(Project project, String prefix) {
+    return prefix + project.getPath();
+  }
+}

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
@@ -12,10 +12,7 @@ import com.uber.okbuck.core.manager.LintManager;
 import com.uber.okbuck.core.manager.ScalaManager;
 import com.uber.okbuck.core.manager.TransformManager;
 import com.uber.okbuck.core.model.base.ProjectType;
-import com.uber.okbuck.core.model.base.Target;
-import com.uber.okbuck.core.model.base.TargetCache;
 import com.uber.okbuck.extension.OkBuckExtension;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -89,15 +86,6 @@ public final class ProjectUtil {
     return getPlugin(project).transformManager;
   }
 
-  public static Map<String, Target> getTargets(Project project) {
-    return getTargetCache(project).getTargets(project);
-  }
-
-  @Nullable
-  public static Target getTargetForVariant(Project targetProject, @Nullable String variant) {
-    return getTargetCache(targetProject).getTargetForVariant(targetProject, variant);
-  }
-
   public static OkBuckGradlePlugin getPlugin(Project project) {
     return project.getRootProject().getPlugins().getPlugin(OkBuckGradlePlugin.class);
   }
@@ -105,10 +93,6 @@ public final class ProjectUtil {
   public static OkBuckExtension getOkBuckExtension(Project project) {
     return (OkBuckExtension)
         project.getRootProject().getExtensions().getByName(OkBuckGradlePlugin.OKBUCK);
-  }
-
-  private static TargetCache getTargetCache(Project project) {
-    return getPlugin(project).targetCache;
   }
 
   @Nullable

--- a/buildSrc/src/main/java/com/uber/okbuck/generator/BuckFileGenerator.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/generator/BuckFileGenerator.java
@@ -26,6 +26,7 @@ import com.uber.okbuck.core.model.android.AndroidLibTarget;
 import com.uber.okbuck.core.model.base.ProjectType;
 import com.uber.okbuck.core.model.base.RuleType;
 import com.uber.okbuck.core.model.jvm.JvmTarget;
+import com.uber.okbuck.core.util.ProjectCache;
 import com.uber.okbuck.core.util.ProjectUtil;
 import com.uber.okbuck.extension.VisibilityExtension;
 import com.uber.okbuck.template.android.AndroidRule;
@@ -66,7 +67,9 @@ public final class BuckFileGenerator {
   private static List<Rule> createRules(Project project) {
     List<Rule> rules = new ArrayList<>();
     ProjectType projectType = ProjectUtil.getType(project);
-    ProjectUtil.getTargets(project)
+
+    ProjectCache.getTargetCache(project)
+        .getTargets()
         .forEach(
             (name, target) -> {
               switch (projectType) {


### PR DESCRIPTION
- Move ScopeCache & TargetCache into ProjectCache class
- Lazy initialize targets of a project
- Reset rootProject's cache extra properties correctly
- Initialize target cache at start of `setupOkbuck` task and reset at end of `rootOkbuckTask`. This can't be done at the local level of a project's okbuck task since the target cache is shared b/w projects.
- Lowers down memory footprint from 1.5 GB to 1GB. 