### PR TITLE
Add support for reading custom Kotlin compiler arguments

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidTestRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidTestRuleComposer.java
@@ -56,7 +56,7 @@ public final class AndroidTestRuleComposer extends AndroidBuckRuleComposer {
             .targetCompatibility(target.getTargetCompatibility())
             .exportedDeps(aidlRuleNames)
             .excludes(appClass != null ? ImmutableSet.of(appClass) : ImmutableSet.of())
-            .options(mapOptions(target.getMain().getCompilerOptions()))
+            .options(mapOptions(target.getTest().getCompilerOptions()))
             .jvmArgs(target.getTestOptions().getJvmArgs())
             .env(target.getTestOptions().getEnv())
             .robolectricManifest(manifestRule)

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidTarget.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidTarget.java
@@ -61,7 +61,7 @@ public abstract class AndroidTarget extends JvmTarget {
   private final String targetSdk;
   private final boolean debuggable;
   private final boolean generateR2;
-  private final boolean isKotlin;
+  private final boolean isKotlinAndroid;
   private final boolean isKapt;
   private final boolean hasKotlinAndroidExtensions;
   private final boolean hasExperimentalKotlinAndroidExtensions;
@@ -100,7 +100,7 @@ public abstract class AndroidTarget extends JvmTarget {
     generateR2 = project.getPlugins().hasPlugin("com.jakewharton.butterknife");
 
     // Check if kotlin
-    isKotlin = project.getPlugins().hasPlugin(KotlinAndroidPluginWrapper.class);
+    isKotlinAndroid = project.getPlugins().hasPlugin(KotlinAndroidPluginWrapper.class);
     isKapt = project.getPlugins().hasPlugin(KOTLIN_KAPT_PLUGIN);
     hasKotlinAndroidExtensions = project.getPlugins().hasPlugin(KOTLIN_ANDROID_EXTENSIONS_MODULE);
 
@@ -146,7 +146,7 @@ public abstract class AndroidTarget extends JvmTarget {
         .sourceDirs(getSources(getBaseVariant()))
         .javaResourceDirs(getJavaResources(getBaseVariant()))
         .compilerOptions(Scope.Builder.COMPILER.JAVA, getJavaCompilerOptions(getBaseVariant()))
-        .compilerOptions(Scope.Builder.COMPILER.KOTLIN, getKotlinCompilerOptions())
+        .compilerOptions(Scope.Builder.COMPILER.KOTLIN, getKotlinCompilerOptions(false))
         .build();
   }
 
@@ -159,7 +159,7 @@ public abstract class AndroidTarget extends JvmTarget {
       builder.sourceDirs(getSources(unitTestVariant));
       builder.javaResourceDirs(getJavaResources(unitTestVariant));
       builder.compilerOptions(Scope.Builder.COMPILER.JAVA, getJavaCompilerOptions(unitTestVariant));
-      builder.compilerOptions(Scope.Builder.COMPILER.KOTLIN, getKotlinCompilerOptions());
+      builder.compilerOptions(Scope.Builder.COMPILER.KOTLIN, getKotlinCompilerOptions(true));
     }
     return builder.build();
   }
@@ -412,9 +412,12 @@ public abstract class AndroidTarget extends JvmTarget {
   }
 
   @Override
-  protected List<String> getKotlinCompilerOptions() {
+  protected List<String> getKotlinCompilerOptions(boolean testOnly) {
+    if (!isKotlin) {
+      return ImmutableList.of();
+    }
     if (!getHasKotlinAndroidExtensions()) {
-      return super.getKotlinCompilerOptions();
+      return super.getKotlinCompilerOptions(testOnly);
     }
 
     ImmutableList.Builder<String> extraKotlincArgs = ImmutableList.builder();
@@ -459,7 +462,7 @@ public abstract class AndroidTarget extends JvmTarget {
     extraKotlincArgs.add("-P");
     extraKotlincArgs.add(options.toString());
 
-    extraKotlincArgs.addAll(super.getKotlinCompilerOptions());
+    extraKotlincArgs.addAll(super.getKotlinCompilerOptions(testOnly));
 
     return extraKotlincArgs.build();
   }
@@ -502,7 +505,7 @@ public abstract class AndroidTarget extends JvmTarget {
   }
 
   public RuleType getRuleType() {
-    if (isKotlin) {
+    if (isKotlinAndroid) {
       return RuleType.KOTLIN_ANDROID_LIBRARY;
     } else {
       return RuleType.ANDROID_LIBRARY;
@@ -510,7 +513,7 @@ public abstract class AndroidTarget extends JvmTarget {
   }
 
   public RuleType getTestRuleType() {
-    if (isKotlin) {
+    if (isKotlinAndroid) {
       return RuleType.KOTLIN_ROBOLECTRIC_TEST;
     } else {
       return RuleType.ROBOLECTRIC_TEST;
@@ -548,7 +551,7 @@ public abstract class AndroidTarget extends JvmTarget {
 
     srcs.addAll(javaSrcs);
 
-    if (isKotlin) {
+    if (isKotlinAndroid) {
       srcs.addAll(
           javaSrcs
               .stream()

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidTarget.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidTarget.java
@@ -413,9 +413,6 @@ public abstract class AndroidTarget extends JvmTarget {
 
   @Override
   protected List<String> getKotlinCompilerOptions(boolean testOnly) {
-    if (!isKotlin) {
-      return ImmutableList.of();
-    }
     if (!getHasKotlinAndroidExtensions()) {
       return super.getKotlinCompilerOptions(testOnly);
     }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/jvm/JvmTarget.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/jvm/JvmTarget.java
@@ -311,7 +311,10 @@ public class JvmTarget extends Target {
       // Args from K2JVMCompilerArguments.kt and KotlinJvmOptions.kt
       optionBuilder.add("-jvm-target", options.getJvmTarget());
       optionBuilder.add("-include-runtime", Boolean.toString(options.getIncludeRuntime()));
-      optionBuilder.add("-jdk-home", options.getJdkHome());
+      String jdkHome = options.getJdkHome();
+      if (jdkHome != null) {
+        optionBuilder.add("-jdk-home", jdkHome);
+      }
       optionBuilder.add("-no-jdk", Boolean.toString(options.getNoJdk()));
       optionBuilder.add("-no-stdlib", Boolean.toString(options.getNoStdlib()));
       optionBuilder.add("-no-reflect", Boolean.toString(options.getNoReflect()));

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/jvm/JvmTarget.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/jvm/JvmTarget.java
@@ -306,7 +306,7 @@ public class JvmTarget extends Target {
       // internal elements.
       // https://github.com/uber/okbuck/issues/709
 
-      optionBuilder.add("-Xfriend-paths=$(location //:" + JvmBuckRuleComposer.src(this) + "[output])");
+      optionBuilder.add("-Xfriend-paths=$(location :" + JvmBuckRuleComposer.src(this) + "[output])");
     }
     return optionBuilder.build();
   }

--- a/kotlin-app/src/main/java/com/uber/okbuck/example/MainActivity.kt
+++ b/kotlin-app/src/main/java/com/uber/okbuck/example/MainActivity.kt
@@ -24,4 +24,8 @@ class MainActivity : DaggerAppCompatActivity() {
         val repo = GithubRepo.create(100, "OkBuck", "auto buck")
         Toast.makeText(this, repo.name + ": " + repo.description, Toast.LENGTH_SHORT).show()
     }
+
+    companion object {
+      internal const val TEST_INTERNAL = ""
+    }
 }

--- a/kotlin-app/src/test/java/com/uber/okbuck/example/InternalTest.kt
+++ b/kotlin-app/src/test/java/com/uber/okbuck/example/InternalTest.kt
@@ -1,0 +1,9 @@
+package com.uber.okbuck.example
+
+class InternalTest {
+
+  // This should compile because tests should be allowed to access `internal` elements of their main
+  // source dir
+  val internalAccess = MainActivity.TEST_INTERNAL
+
+}

--- a/libraries/kotlinlibrary/src/main/java/demo/helloWorld.kt
+++ b/libraries/kotlinlibrary/src/main/java/demo/helloWorld.kt
@@ -1,5 +1,7 @@
 package demo
 
+internal const val INTERNAL_GREETING = "Hello internal world!"
+
 fun getGreeting(): String {
     val words = mutableListOf<String>()
     words.add("Hello,")

--- a/libraries/kotlinlibrary/src/test/java/demo/HelloWorldTest.kt
+++ b/libraries/kotlinlibrary/src/test/java/demo/HelloWorldTest.kt
@@ -10,4 +10,7 @@ class HelloWorldTest {
     @Test fun fooVoid() {
         assertEquals("Hello, world!", JavaClass().kotlinGreeting)
     }
+    @Test fun internalUsage() {
+        assertEquals("Hello internal world!", INTERNAL_GREETING)
+    }
 }


### PR DESCRIPTION
This builds on #775 and adds support for reading compiler configuration directly from the kotlin compile task. Not written tests yet because I want to wait for #775 to get in, but it's a start and want to get this up now for early feedback.

This supports all the standard arguments configurable by the gradle plugin, as well as the important free arguments option to add new ones
