### PR TITLE
Remove redundant kotlin_home config param target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ defaults: &defaults
     SKIP_OKBUCK: true
     NO_BUCKD: 1
     EXTRA_OKBUCK_ARGS: --stacktrace
-    JVM_OPTS: -Xmx3200m
+    JVM_OPTS: -Xmx3072m
 
 aliases:
   - &restore-wrapper-cache
@@ -52,7 +52,7 @@ jobs:
       - *save-gradle-cache
       - run:
           name: Build all non lint targets
-          command: ./buckw targets //... --type android_binary android_instrumentation_apk java_test groovy_test robolectric_test kotlin_test scala_test | xargs ./buckw build -v 6
+          command: ./buckw targets //... --type android_binary android_instrumentation_apk java_test groovy_test robolectric_test kotlin_test scala_test | xargs ./buckw build
           shell: "/bin/bash"
   lint:
     <<: *defaults
@@ -66,7 +66,7 @@ jobs:
       - run:
           name: Build all lint targets, except for lint error library
           command: |-
-            ./buckw targets //... --type genrule | grep -v lintErrorLibrary | xargs ./buckw build -v 6 && \
+            ./buckw targets //... --type genrule | grep -v lintErrorLibrary | xargs ./buckw build && \
             ./tooling/ci/lint_integration_test.sh
           shell: "/bin/bash"
   unit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - *save-gradle-cache
       - run:
           name: Build all non lint targets
-          command: ./buckw targets //... --type android_binary android_instrumentation_apk java_test groovy_test robolectric_test kotlin_test scala_test | xargs ./buckw build
+          command: ./buckw targets //... --type android_binary android_instrumentation_apk java_test groovy_test robolectric_test kotlin_test scala_test | xargs ./buckw build -v 6
           shell: "/bin/bash"
   lint:
     <<: *defaults
@@ -66,7 +66,7 @@ jobs:
       - run:
           name: Build all lint targets, except for lint error library
           command: |-
-            ./buckw targets //... --type genrule | grep -v lintErrorLibrary | xargs ./buckw build && \
+            ./buckw targets //... --type genrule | grep -v lintErrorLibrary | xargs ./buckw build -v 6 && \
             ./tooling/ci/lint_integration_test.sh
           shell: "/bin/bash"
   unit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - *save-gradle-cache
       - run:
           name: Build all non lint targets
-          command: ./buckw targets //... --type android_binary android_instrumentation_apk java_test groovy_test robolectric_test kotlin_test scala_test | xargs ./buckw build -v 0
+          command: ./buckw targets //... --type android_binary android_instrumentation_apk java_test groovy_test robolectric_test kotlin_test scala_test | xargs ./buckw build
           shell: "/bin/bash"
   lint:
     <<: *defaults
@@ -66,7 +66,7 @@ jobs:
       - run:
           name: Build all lint targets, except for lint error library
           command: |-
-            ./buckw targets //... --type genrule | grep -v lintErrorLibrary | xargs ./buckw build -v 0 && \
+            ./buckw targets //... --type genrule | grep -v lintErrorLibrary | xargs ./buckw build && \
             ./tooling/ci/lint_integration_test.sh
           shell: "/bin/bash"
   unit:

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckConfig.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckConfig.rocker.raw
@@ -24,7 +24,6 @@ Map mavenRepositories,
 
 [kotlin]
     kotlin_home = @kotlinHome
-    target = true
 }
 @if (valid(scalaCompiler) && valid(scalaLibrary)) {
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,3 +1,7 @@
+// CI keeps gradle home cached based on the SHA of this file.
+// Update below to invalidate the cache.
+// Gradle Cache Version 1
+
 def versions = [
         androidPlugin      : "3.2.0",
         androidTools       : "26.2.0",


### PR DESCRIPTION
- `target` is not needed in `kotlin_home` 
- Add an option to invalidate gradle cache
- Don't build with `-v 0`
