### PR TITLE
Add support for reading custom kotlin compiler args

### DIFF
--- a/kotlin-app/build.gradle
+++ b/kotlin-app/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 apply plugin: "com.android.application"
 apply plugin: "com.squareup.sqldelight"
 apply plugin: "kotlin-android"
@@ -11,6 +13,14 @@ android {
     }
 
     flavorDimensions "default"
+}
+
+tasks.withType(KotlinCompile).all {
+    kotlinOptions {
+        jvmTarget = '1.7'
+        allWarningsAsErrors = true
+        freeCompilerArgs = ['-progressive', '-Xjsr305=strict']
+    }
 }
 
 dependencies {

--- a/libraries/kotlinandroidlibrary/build.gradle
+++ b/libraries/kotlinandroidlibrary/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply plugin: "kotlin-android-extensions"
@@ -30,5 +32,13 @@ android {
 
     defaultConfig {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+}
+
+tasks.withType(KotlinCompile).all {
+    kotlinOptions {
+        jvmTarget = '1.7'
+        allWarningsAsErrors = true
+        freeCompilerArgs = ['-progressive', '-Xjsr305=strict']
     }
 }

--- a/libraries/kotlinlibrary/build.gradle
+++ b/libraries/kotlinlibrary/build.gradle
@@ -16,3 +16,11 @@ allOpen {
   annotations("demo.Anno")
   annotations("demo.Anno2")
 }
+
+compileKotlin {
+  kotlinOptions {
+    jvmTarget = '1.7'
+    allWarningsAsErrors = true
+    freeCompilerArgs = ['-progressive', '-Xjsr305=strict']
+  }
+}


### PR DESCRIPTION
Rekick from #777

Removed test-specific support as I'm not convinced that it it's something we should go out of our way to support (and not even possible on android projects). It just grabs the first KotlinCompile task and applies that to all configurations