### PR TITLE
Stop forcing kotlin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,6 @@ buildscript {
     }
     configurations.all {
         exclude group:"com.android.tools.build", module: "transform-api"
-        resolutionStrategy {
-            force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${deps.versions.kotlin}"
-        }
     }
 }
 
@@ -30,9 +27,6 @@ allprojects { project ->
     }
     configurations.all {
         exclude group:"com.android.tools.build", module: "transform-api"
-        resolutionStrategy {
-            force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${deps.versions.kotlin}"
-        }
     }
 }
 
@@ -233,12 +227,14 @@ okbuck {
             "org.apache.httpcomponents:httpcore",
             "com.android.tools:repository",
             "org.jetbrains.kotlin:kotlin-stdlib",
+            "org.jetbrains.kotlin:kotlin-reflect",
+            "org.jetbrains.kotlin:kotlin-stdlib-common",
+            "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
             "org.ow2.asm:asm-tree",
             "org.apache.httpcomponents:httpclient",
             "org.bouncycastle:bcprov-jdk15on",
             "commons-logging:commons-logging",
             "com.squareup:javapoet",
-            "org.jetbrains.kotlin:kotlin-reflect",
             "org.checkerframework:checker-compat-qual",
             "com.google.code.gson:gson",
             "com.android.tools.build:builder-model",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -32,7 +32,7 @@ def build = [
         rockerPlugin     : "gradle.plugin.com.fizzed:rocker-gradle-plugin:${versions.rocker}",
         rockerRuntime    : "com.fizzed:rocker-runtime:${versions.rocker}",
         shadowJar        : "com.github.jengelman.gradle.plugins:shadow:2.0.1",
-        sqlDelightPlugin : "com.squareup.sqldelight:gradle-plugin:1.0.0-rc2",
+        sqlDelightPlugin : "com.squareup.sqldelight:gradle-plugin:1.0.2",
 ]
 
 def buildConfig = [


### PR DESCRIPTION
Updates sqldelight dependency so we can stop forcing kotlin-stdlib-jdk to okbuck's kotlin version (old sqldelight release pointed to a version which our defined repositories couldn't find).
