### PR TITLE
Adding arm64-v8a as a supported ABI to okbuck

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidBinaryRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidBinaryRuleComposer.java
@@ -20,7 +20,8 @@ public final class AndroidBinaryRuleComposer extends AndroidBuckRuleComposer {
       ImmutableMap.of(
           "armeabi", "ARM",
           "armeabi-v7a", "ARMV7",
-          "arm64-v8a",
+          "arm64", "ARM64",
+          "arm64-v8a", "ARM64_V8A",
           "x86", "X86",
           "x86_64", "X86_64",
           "mips", "MIPS");

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidBinaryRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidBinaryRuleComposer.java
@@ -17,13 +17,14 @@ import org.apache.commons.lang3.tuple.Pair;
 public final class AndroidBinaryRuleComposer extends AndroidBuckRuleComposer {
 
   private static final ImmutableMap<String, String> CPU_FILTER_MAP =
-      ImmutableMap.of(
-          "armeabi", "ARM",
-          "armeabi-v7a", "ARMV7",
-          "arm64-v8a", "ARMV8_64",
-          "x86", "X86",
-          "x86_64", "X86_64",
-          "mips", "MIPS");
+      new ImmutableMap.Builder<>()
+          .put("armeabi", "ARM")
+          .put("armeabi-v7a", "ARMV7")
+          .put("arm64-v8a", "ARM64")
+          .put("x86", "X86")
+          .put("x86_64", "X86_64")
+          .put("mips", "MIPS")
+          .build();
 
   private AndroidBinaryRuleComposer() {
     // no instance

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidBinaryRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidBinaryRuleComposer.java
@@ -20,6 +20,7 @@ public final class AndroidBinaryRuleComposer extends AndroidBuckRuleComposer {
       ImmutableMap.of(
           "armeabi", "ARM",
           "armeabi-v7a", "ARMV7",
+          "arm64-v8a",
           "x86", "X86",
           "x86_64", "X86_64",
           "mips", "MIPS");

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidBinaryRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidBinaryRuleComposer.java
@@ -20,8 +20,7 @@ public final class AndroidBinaryRuleComposer extends AndroidBuckRuleComposer {
       ImmutableMap.of(
           "armeabi", "ARM",
           "armeabi-v7a", "ARMV7",
-          "arm64", "ARM64",
-          "arm64-v8a", "ARM64_V8A",
+          "arm64-v8a", "ARMV8_64",
           "x86", "X86",
           "x86_64", "X86_64",
           "mips", "MIPS");

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidBinaryRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidBinaryRuleComposer.java
@@ -17,7 +17,7 @@ import org.apache.commons.lang3.tuple.Pair;
 public final class AndroidBinaryRuleComposer extends AndroidBuckRuleComposer {
 
   private static final ImmutableMap<String, String> CPU_FILTER_MAP =
-      new ImmutableMap.Builder<>()
+      new ImmutableMap.Builder<String, String>()
           .put("armeabi", "ARM")
           .put("armeabi-v7a", "ARMV7")
           .put("arm64-v8a", "ARM64")


### PR DESCRIPTION
* Simply adding support to `arm64-v8a` as a recognizable attribute for ABI in okbuck

Pulling in the `ARM64` enum from - https://github.com/facebook/buck/blob/a6c7d7391a7a8e575c6372cac6690a240b5907ea/src/com/facebook/buck/android/toolchain/ndk/TargetCpuType.java