### PR TITLE
[Demo diff] Added support for reading multiDexEnabled from build type based config

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidAppTarget.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidAppTarget.java
@@ -52,12 +52,9 @@ public class AndroidAppTarget extends AndroidLibTarget {
     Set<String> filters = ndkCompile != null ? ndkCompile.getAbiFilters() : ImmutableSet.of();
     cpuFilters = filters != null ? filters : ImmutableSet.of();
 
-    Boolean multidex = getBaseVariant().getMergedFlavor().getMultiDexEnabled();
-    if (multidex == null) {
-      multidexEnabled = false;
-    } else {
-      multidexEnabled = multidex;
-    }
+    multidexEnabled = Optional.ofNullable(getBaseVariant().getBuildType().getMultiDexEnabled())
+            .orElse(Optional.ofNullable(getBaseVariant().getMergedFlavor().getMultiDexEnabled())
+                    .orElse(false));
 
     primaryDexPatterns = getProp(getOkbuck().primaryDexPatterns, ImmutableList.of());
     linearAllocHardLimit = getProp(getOkbuck().linearAllocHardLimit, DEFAULT_LINEARALLOC_LIMIT);


### PR DESCRIPTION
Demo diff for https://github.com/uber/okbuck/issues/828. It first checks whether `multiDexEnabled` is defined in `buildType`. If not present, then check  in `defaultConfig`.
