### PR TITLE
Add support for composing api deps in external_deps.

### DIFF
--- a/another-app/build.gradle
+++ b/another-app/build.gradle
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    implementation deps.androidx.appCompat
+    api deps.androidx.appCompat
     implementation project(":libraries:javalibrary")
     implementation project(":libraries:emptylibrary")
     implementation project(":libraries:parcelable")

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -99,7 +99,7 @@ task sourcesJar(type: Jar) {
     classifier = "sources"
 }
 
-def publishVersion = "0.47.5-LOCAL"
+def publishVersion = "0.47.1"
 group = "com.uber"
 version = publishVersion
 def siteUrl = "https://github.com/uber/okbuck"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -99,7 +99,7 @@ task sourcesJar(type: Jar) {
     classifier = "sources"
 }
 
-def publishVersion = "0.47.1"
+def publishVersion = "0.47.5-LOCAL"
 group = "com.uber"
 version = publishVersion
 def siteUrl = "https://github.com/uber/okbuck"

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidLibraryRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidLibraryRuleComposer.java
@@ -32,24 +32,28 @@ public final class AndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
       @Nullable String appClass) {
 
     Set<String> libraryDeps = new HashSet<>(deps);
-    libraryDeps.addAll(external(getExternalDeps(target.getMain(), target.getProvided())));
-    libraryDeps.addAll(targets(getTargetDeps(target.getMain(), target.getProvided())));
-
-    List<String> libraryAptDeps = new ArrayList<>();
-    libraryAptDeps.addAll(externalApt(target.getApt().getExternalJarDeps()));
-    libraryAptDeps.addAll(targetsApt(target.getApt().getTargetDeps()));
-
-    Set<String> providedDeps = new HashSet<>();
-    providedDeps.addAll(external(getExternalProvidedDeps(target.getMain(), target.getProvided())));
-    providedDeps.addAll(targets(getTargetProvidedDeps(target.getMain(), target.getProvided())));
-    providedDeps.add(D8Util.RT_STUB_JAR_RULE);
-
+    libraryDeps.addAll(external(target.getExternalDeps(false)));
+    libraryDeps.addAll(targets(target.getTargetDeps(false)));
     libraryDeps.addAll(
-        getTargetDeps(target.getMain(), target.getProvided())
+        target
+            .getTargetDeps(false)
             .stream()
             .filter(targetDep -> targetDep instanceof AndroidTarget)
             .map(targetDep -> resRule((AndroidTarget) targetDep))
             .collect(Collectors.toSet()));
+
+    List<String> libraryAptDeps = new ArrayList<>();
+    libraryAptDeps.addAll(externalApt(target.getExternalAptDeps(false)));
+    libraryAptDeps.addAll(targetsApt(target.getTargetAptDeps(false)));
+
+    Set<String> providedDeps = new HashSet<>();
+    providedDeps.addAll(external(target.getExternalProvidedDeps(false)));
+    providedDeps.addAll(targets(target.getTargetProvidedDeps(false)));
+    providedDeps.add(D8Util.RT_STUB_JAR_RULE);
+
+    Set<String> libraryExportedDeps = new HashSet<>();
+    libraryExportedDeps.addAll(external(target.getExternalExportedDeps(false)));
+    libraryExportedDeps.addAll(targets(target.getTargetExportedDeps(false)));
 
     List<String> testTargets = new ArrayList<>();
     if (target.getRobolectricEnabled() && !target.getTest().getSources().isEmpty()) {
@@ -70,6 +74,7 @@ public final class AndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
             .apPlugins(getApPlugins(target.getApPlugins()))
             .aptDeps(libraryAptDeps)
             .providedDeps(providedDeps)
+            .exportedDeps(libraryExportedDeps)
             .resources(target.getMain().getJavaResources())
             .resDirs(target.getResDirs())
             .sourceCompatibility(target.getSourceCompatibility())

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidResourceRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidResourceRuleComposer.java
@@ -19,7 +19,8 @@ public final class AndroidResourceRuleComposer extends AndroidBuckRuleComposer {
     List<String> resDeps = new ArrayList<>();
     resDeps.addAll(external(new HashSet<>(target.getMain().getExternalAarDeps())));
     resDeps.addAll(
-        getTargetDeps(target.getMain(), target.getProvided())
+        target
+            .getTargetDeps(false)
             .stream()
             .filter(targetDep -> targetDep instanceof AndroidTarget)
             .map(targetDep -> resRule((AndroidTarget) targetDep))

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidTestRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidTestRuleComposer.java
@@ -31,17 +31,16 @@ public final class AndroidTestRuleComposer extends AndroidBuckRuleComposer {
 
     List<String> testDeps = new ArrayList<>(deps);
     testDeps.add(":" + src(target));
-    testDeps.addAll(external(getExternalDeps(target.getTest(), target.getTestProvided())));
-    testDeps.addAll(targets(getTargetDeps(target.getTest(), target.getTestProvided())));
+    testDeps.addAll(external(target.getExternalDeps(true)));
+    testDeps.addAll(targets(target.getTargetDeps(true)));
 
     List<String> testAptDeps = new ArrayList<>();
-    testAptDeps.addAll(external(target.getTestApt().getExternalDeps()));
-    testAptDeps.addAll(targets(target.getTestApt().getTargetDeps()));
+    testAptDeps.addAll(external(target.getExternalAptDeps(true)));
+    testAptDeps.addAll(targets(target.getTargetAptDeps(true)));
 
     Set<String> providedDeps = new LinkedHashSet<>();
-    providedDeps.addAll(
-        external(getExternalProvidedDeps(target.getTest(), target.getTestProvided())));
-    providedDeps.addAll(targets(getTargetProvidedDeps(target.getTest(), target.getTestProvided())));
+    providedDeps.addAll(external(target.getExternalProvidedDeps(true)));
+    providedDeps.addAll(targets(target.getTargetProvidedDeps(true)));
     providedDeps.add(D8Util.RT_STUB_JAR_RULE);
 
     AndroidTestRule androidTest =

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/jvm/JvmBuckRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/jvm/JvmBuckRuleComposer.java
@@ -1,11 +1,7 @@
 package com.uber.okbuck.composer.jvm;
 
-import com.google.common.collect.Sets;
 import com.uber.okbuck.OkBuckGradlePlugin;
 import com.uber.okbuck.composer.base.BuckRuleComposer;
-import com.uber.okbuck.core.dependency.ExternalDependency;
-import com.uber.okbuck.core.model.base.Scope;
-import com.uber.okbuck.core.model.base.Target;
 import com.uber.okbuck.core.model.jvm.JvmTarget;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -22,54 +18,6 @@ public class JvmBuckRuleComposer extends BuckRuleComposer {
 
   public static String test(JvmTarget target) {
     return "test_" + target.getName();
-  }
-
-  /**
-   * Get api and implementation target deps. deps = runtimeClasspath(api + implementation +
-   * runtimeOnly) intersect compileClasspath(api + implementation + compileOnly)
-   *
-   * @param runtime RuntimeClasspath scope
-   * @param compile CompileClasspath scope
-   * @return Target deps
-   */
-  public static Set<Target> getTargetDeps(Scope runtime, Scope compile) {
-    return Sets.intersection(runtime.getTargetDeps(), compile.getTargetDeps());
-  }
-
-  /**
-   * Get compileOnly target deps. compileOnlyDeps = compileClasspath(api + implementation +
-   * compileOnly) - runtimeClasspath(api + implementation + runtimeOnly)
-   *
-   * @param runtime RuntimeClasspath scope
-   * @param compile CompileClasspath scope
-   * @return CompileOnly Target deps
-   */
-  public static Set<Target> getTargetProvidedDeps(Scope runtime, Scope compile) {
-    return Sets.difference(compile.getTargetDeps(), runtime.getTargetDeps());
-  }
-
-  /**
-   * Get api and implementation external deps. deps = runtimeClasspath(api + implementation +
-   * runtimeOnly) intersect compileClasspath(api + implementation + compileOnly)
-   *
-   * @param runtime RuntimeClasspath scope
-   * @param compile CompileClasspath scope
-   * @return External deps
-   */
-  public static Set<ExternalDependency> getExternalDeps(Scope runtime, Scope compile) {
-    return Sets.intersection(runtime.getExternalDeps(), compile.getExternalDeps());
-  }
-
-  /**
-   * Get compileOnly external deps. compileOnlyDeps = compileClasspath(api + implementation +
-   * compileOnly) - runtimeClasspath(api + implementation + runtimeOnly)
-   *
-   * @param runtime RuntimeClasspath scope
-   * @param compile CompileClasspath scope
-   * @return CompileOnly Target deps
-   */
-  public static Set<ExternalDependency> getExternalProvidedDeps(Scope runtime, Scope compile) {
-    return Sets.difference(compile.getExternalDeps(), runtime.getExternalDeps());
   }
 
   /**

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/jvm/JvmLibraryRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/jvm/JvmLibraryRuleComposer.java
@@ -20,20 +20,26 @@ public final class JvmLibraryRuleComposer extends JvmBuckRuleComposer {
   public static ImmutableList<Rule> compose(JvmTarget target, RuleType ruleType) {
     List<String> deps =
         ImmutableList.<String>builder()
-            .addAll(external(getExternalDeps(target.getMain(), target.getProvided())))
-            .addAll(targets(getTargetDeps(target.getMain(), target.getProvided())))
+            .addAll(external(target.getExternalDeps(false)))
+            .addAll(targets(target.getTargetDeps(false)))
             .build();
 
     Set<String> aptDeps =
         ImmutableSet.<String>builder()
-            .addAll(externalApt(target.getApt().getExternalJarDeps()))
-            .addAll(targetsApt(target.getApt().getTargetDeps()))
+            .addAll(externalApt(target.getExternalAptDeps(false)))
+            .addAll(targetsApt(target.getTargetAptDeps(false)))
             .build();
 
     Set<String> providedDeps =
         ImmutableSet.<String>builder()
-            .addAll(external(getExternalProvidedDeps(target.getMain(), target.getProvided())))
-            .addAll(targets(getTargetProvidedDeps(target.getMain(), target.getProvided())))
+            .addAll(external(target.getExternalProvidedDeps(false)))
+            .addAll(targets(target.getTargetProvidedDeps(false)))
+            .build();
+
+    Set<String> exportedDeps =
+        ImmutableSet.<String>builder()
+            .addAll(external(target.getExternalExportedDeps(false)))
+            .addAll(targets(target.getTargetExportedDeps(false)))
             .build();
 
     List<String> testTargets =
@@ -49,6 +55,7 @@ public final class JvmLibraryRuleComposer extends JvmBuckRuleComposer {
             .apPlugins(getApPlugins(target.getApPlugins()))
             .aptDeps(aptDeps)
             .providedDeps(providedDeps)
+            .exportedDeps(exportedDeps)
             .resources(target.getMain().getJavaResources())
             .sourceCompatibility(target.getSourceCompatibility())
             .targetCompatibility(target.getTargetCompatibility())

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/jvm/JvmTestRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/jvm/JvmTestRuleComposer.java
@@ -21,20 +21,20 @@ public final class JvmTestRuleComposer extends JvmBuckRuleComposer {
     List<String> deps =
         ImmutableList.<String>builder()
             .add(":" + src(target))
-            .addAll(external(getExternalDeps(target.getTest(), target.getTestProvided())))
-            .addAll(targets(getTargetDeps(target.getTest(), target.getTestProvided())))
+            .addAll(external(target.getExternalDeps(true)))
+            .addAll(targets(target.getTargetDeps(true)))
             .build();
 
     Set<String> aptDeps =
         ImmutableSet.<String>builder()
-            .addAll(external(target.getTestApt().getExternalDeps()))
-            .addAll(targets(target.getTestApt().getTargetDeps()))
+            .addAll(external(target.getExternalAptDeps(true)))
+            .addAll(targets(target.getTargetAptDeps(true)))
             .build();
 
     Set<String> providedDeps =
         ImmutableSet.<String>builder()
-            .addAll(external(getExternalProvidedDeps(target.getTest(), target.getTestProvided())))
-            .addAll(targets(getTargetProvidedDeps(target.getTest(), target.getTestProvided())))
+            .addAll(external(target.getExternalProvidedDeps(true)))
+            .addAll(targets(target.getTargetProvidedDeps(true)))
             .build();
 
     return new JvmRule()

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyCache.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyCache.java
@@ -47,7 +47,7 @@ public class DependencyCache {
       Scope.builder(project)
           .configuration(forcedConfiguration)
           .build()
-          .getExternal()
+          .getAllExternal()
           .forEach(
               dependency -> {
                 get(dependency);

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyFactory.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyFactory.java
@@ -5,6 +5,7 @@ import com.uber.okbuck.extension.JetifierExtension;
 import java.io.File;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FilenameUtils;
+import org.gradle.api.artifacts.Dependency;
 
 public final class DependencyFactory {
 
@@ -80,6 +81,27 @@ public final class DependencyFactory {
         localSourceDependency,
         externalDependenciesExtension,
         jetifierExtension);
+  }
+
+  /**
+   * Returns a versionless dependency from the given gradle dependency.
+   *
+   * @param dependency gradle dependency
+   * @return VersionlessDependency object
+   */
+  public static VersionlessDependency fromDependency(Dependency dependency) {
+    VersionlessDependency.Builder vDependency =
+        VersionlessDependency.builder().setName(dependency.getName());
+
+    String group = dependency.getGroup();
+    if (group == null) {
+      vDependency.setGroup(LOCAL_GROUP);
+    } else {
+      vDependency.setGroup(group);
+    }
+
+    // TODO: Add support of specifying classifier
+    return vDependency.build();
   }
 
   /**

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyUtils.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyUtils.java
@@ -35,13 +35,18 @@ public final class DependencyUtils {
   private DependencyUtils() {}
 
   @Nullable
-  public static Configuration useful(String configuration, Project project) {
+  public static Configuration getConfiguration(String configuration, Project project) {
     try {
-      Configuration config = project.getConfigurations().getByName(configuration);
-      return useful(config);
+      return project.getConfigurations().getByName(configuration);
     } catch (UnknownConfigurationException ignored) {
       return null;
     }
+  }
+
+  @Nullable
+  public static Configuration useful(String configuration, Project project) {
+    Configuration config = getConfiguration(configuration, project);
+    return useful(config);
   }
 
   @Nullable

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidAppTarget.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidAppTarget.java
@@ -8,6 +8,8 @@ import com.android.builder.model.SigningConfig;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.uber.okbuck.core.dependency.ExternalDependency;
+import com.uber.okbuck.core.model.base.Target;
 import com.uber.okbuck.core.util.FileUtil;
 import com.uber.okbuck.core.util.ProjectUtil;
 import com.uber.okbuck.extension.TestExtension;
@@ -98,6 +100,18 @@ public class AndroidAppTarget extends AndroidLibTarget {
     Preconditions.checkArgument(optionalBaseVariant.isPresent());
 
     return optionalBaseVariant.get();
+  }
+
+  @Override
+  public Set<ExternalDependency> getApiExternalDeps() {
+    // App targets don't have any deps to export
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<Target> getApiTargetDeps() {
+    // App targets don't have any deps to export
+    return ImmutableSet.of();
   }
 
   @Override

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidTarget.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidTarget.java
@@ -168,7 +168,7 @@ public abstract class AndroidTarget extends JvmTarget {
 
   @Override
   public List<Scope> getAptScopes() {
-    Configuration configuration = getConfigurationFromVariant(getBaseVariant());
+    Configuration configuration = getAptConfigurationFromVariant(getBaseVariant());
     AnnotationProcessorCache apCache = ProjectUtil.getAnnotationProcessorCache(getProject());
     return configuration != null
         ? apCache.getAnnotationProcessorScopes(getProject(), configuration)
@@ -177,7 +177,7 @@ public abstract class AndroidTarget extends JvmTarget {
 
   @Override
   public List<Scope> getTestAptScopes() {
-    Configuration configuration = getConfigurationFromVariant(getUnitTestVariant());
+    Configuration configuration = getAptConfigurationFromVariant(getUnitTestVariant());
     AnnotationProcessorCache apCache = ProjectUtil.getAnnotationProcessorCache(getProject());
     return configuration != null
         ? apCache.getAnnotationProcessorScopes(getProject(), configuration)
@@ -186,7 +186,7 @@ public abstract class AndroidTarget extends JvmTarget {
 
   @Override
   public Scope getApt() {
-    Configuration configuration = getConfigurationFromVariant(getBaseVariant());
+    Configuration configuration = getAptConfigurationFromVariant(getBaseVariant());
     return configuration != null
         ? getAptScopeForConfiguration(configuration)
         : Scope.builder(getProject()).build();
@@ -194,7 +194,7 @@ public abstract class AndroidTarget extends JvmTarget {
 
   @Override
   public Scope getTestApt() {
-    Configuration configuration = getConfigurationFromVariant(getUnitTestVariant());
+    Configuration configuration = getAptConfigurationFromVariant(getUnitTestVariant());
     return configuration != null
         ? getAptScopeForConfiguration(configuration)
         : Scope.builder(getProject()).build();
@@ -520,7 +520,7 @@ public abstract class AndroidTarget extends JvmTarget {
   }
 
   @Nullable
-  private Configuration getConfigurationFromVariant(@Nullable BaseVariant variant) {
+  private Configuration getAptConfigurationFromVariant(@Nullable BaseVariant variant) {
     @Var Configuration configuration = null;
     if (isKapt) {
       configuration =

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/android/ExoPackageScope.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/android/ExoPackageScope.java
@@ -105,7 +105,7 @@ public class ExoPackageScope extends Scope {
           }
 
           Optional<ExternalDependency> externalDepOptional =
-              base.getExternal()
+              base.getAllExternal()
                   .stream()
                   .filter(
                       dependency -> {
@@ -119,7 +119,7 @@ public class ExoPackageScope extends Scope {
                   .findFirst();
 
           if (externalDepOptional.isPresent()) {
-            getExternal().add(externalDepOptional.get());
+            getAllExternal().add(externalDepOptional.get());
           } else {
             Optional<Target> variantDepOptional =
                 base.getTargetDeps()

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/base/Scope.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/base/Scope.java
@@ -69,15 +69,11 @@ public class Scope {
     return sources;
   }
 
-  public final Set<Target> getTargetDeps() {
-    return targetDeps;
-  }
-
   public Map<String, List<String>> getCustomOptions() {
     return customOptions;
   }
 
-  public final Set<ExternalDependency> getExternal() {
+  public final Set<ExternalDependency> getAllExternal() {
     return external;
   }
 
@@ -124,22 +120,24 @@ public class Scope {
         ProjectUtil.getDependencyCache(project));
   }
 
+  public final Set<Target> getTargetDeps() {
+    return targetDeps;
+  }
+
   public Set<ExternalDependency> getExternalDeps() {
-    return external.stream().map(depCache::get).collect(Collectors.toSet());
+    return getAllExternal().stream().map(depCache::get).collect(Collectors.toSet());
   }
 
   public Set<ExternalDependency> getExternalJarDeps() {
-    return external
+    return getExternalDeps()
         .stream()
-        .map(depCache::get)
         .filter(dependency -> dependency.getPackaging().equals(JAR))
         .collect(Collectors.toSet());
   }
 
   public Set<ExternalDependency> getExternalAarDeps() {
-    return external
+    return getExternalDeps()
         .stream()
-        .map(depCache::get)
         .filter(dependency -> dependency.getPackaging().equals(AAR))
         .collect(Collectors.toSet());
   }
@@ -172,7 +170,7 @@ public class Scope {
 
       annotationProcessors =
           Streams.concat(
-                  external
+                  getExternalDeps()
                       .stream()
                       .filter(
                           dependency ->
@@ -209,7 +207,7 @@ public class Scope {
    * @return boolean whether the scope has any auto value extension.
    */
   public boolean hasAutoValueExtensions() {
-    return external.stream().anyMatch(depCache::hasAutoValueExtensions);
+    return getExternalDeps().stream().anyMatch(depCache::hasAutoValueExtensions);
   }
 
   /**
@@ -300,8 +298,6 @@ public class Scope {
   }
 
   private void extractConfiguration(Configuration configuration) {
-    Set<ComponentIdentifier> artifactIds = new HashSet<>();
-
     Set<ResolvedArtifactResult> jarArtifacts =
         getArtifacts(configuration, PROJECT_FILTER, ImmutableList.of("jar"));
 

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/android/AndroidRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/android/AndroidRule.rocker.raw
@@ -43,6 +43,7 @@ testTargets,
 apPlugins,
 aptDeps,
 providedDeps,
+exportedDeps,
 libDeps,
 options,
 jvmArgs,
@@ -53,13 +54,6 @@ env
 }
 @if (valid(robolectricManifest)) {
     robolectric_manifest = '@robolectricManifest',
-}
-@if (valid(exportedDeps)) {
-    exported_deps = [
-    @for (exportedDep : sorted(exportedDeps)) {
-        '@exportedDep',
-    }
-    ],
 }
 @if (generateR2) {
     final_r_name = 'R2',

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/jvm/JvmRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/jvm/JvmRule.rocker.raw
@@ -12,6 +12,7 @@ Collection testTargets,
 Collection apPlugins,
 Collection aptDeps,
 Collection providedDeps,
+Collection exportedDeps,
 Collection libDeps,
 Map options,
 Collection jvmArgs,
@@ -81,6 +82,13 @@ lib_deps = []
     provided_deps = [
     @for (providedDep : sorted(providedDeps)) {
         '@providedDep',
+    }
+    ],
+}
+@if (valid(exportedDeps)) {
+    exported_deps = [
+    @for (exportedDep : sorted(exportedDeps)) {
+        '@exportedDep',
     }
     ],
 }

--- a/libraries/javalibrary/build.gradle
+++ b/libraries/javalibrary/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "java-library"
 
 dependencies {
-    implementation deps.external.gson
+    api deps.external.gson
     implementation deps.external.dagger
 
     annotationProcessor deps.apt.javax


### PR DESCRIPTION
- This adds a preliminary support for external_deps.
- `deps` still contains the transitive api deps — will be cleaned in subsequent pr’s.
- Verified that the exported_deps are being composed correctly for java & android libraries.