### PR TITLE
Add support for exported_deps for aar & jar prebuilts.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,11 +185,11 @@ okbuck {
     }
 
     kotlin {
-        version = config.versions.kotlin
+        version = deps.versions.kotlin
     }
 
     lint {
-        version = config.versions.androidTools
+        version = deps.versions.androidTools
         jvmArgs = '-Xmx1g'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -185,11 +185,11 @@ okbuck {
     }
 
     kotlin {
-        version = deps.versions.kotlin
+        version = config.versions.kotlin
     }
 
     lint {
-        version = deps.versions.androidTools
+        version = config.versions.androidTools
         jvmArgs = '-Xmx1g'
     }
 

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidBuckRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidBuckRuleComposer.java
@@ -3,6 +3,9 @@ package com.uber.okbuck.composer.android;
 import com.uber.okbuck.composer.jvm.JvmBuckRuleComposer;
 import com.uber.okbuck.core.model.android.AndroidAppTarget;
 import com.uber.okbuck.core.model.android.AndroidTarget;
+import com.uber.okbuck.core.model.base.Target;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public abstract class AndroidBuckRuleComposer extends JvmBuckRuleComposer {
 
@@ -52,5 +55,13 @@ public abstract class AndroidBuckRuleComposer extends JvmBuckRuleComposer {
 
   static String instrumentationTest(AndroidAppTarget target) {
     return "instrumentation_" + target.getName() + "_test";
+  }
+
+  static Set<String> resources(Set<Target> targets) {
+    return targets
+        .stream()
+        .filter(targetDep -> targetDep instanceof AndroidTarget)
+        .map(targetDep -> resRule((AndroidTarget) targetDep))
+        .collect(Collectors.toSet());
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidLibraryRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidLibraryRuleComposer.java
@@ -3,7 +3,6 @@ package com.uber.okbuck.composer.android;
 import com.google.common.collect.ImmutableSet;
 import com.uber.okbuck.composer.base.BuckRuleComposer;
 import com.uber.okbuck.core.model.android.AndroidLibTarget;
-import com.uber.okbuck.core.model.android.AndroidTarget;
 import com.uber.okbuck.core.model.base.RuleType;
 import com.uber.okbuck.core.model.jvm.JvmTarget;
 import com.uber.okbuck.core.util.D8Util;
@@ -34,13 +33,8 @@ public final class AndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
     Set<String> libraryDeps = new HashSet<>(deps);
     libraryDeps.addAll(external(target.getExternalDeps(false)));
     libraryDeps.addAll(targets(target.getTargetDeps(false)));
-    libraryDeps.addAll(
-        target
-            .getTargetDeps(false)
-            .stream()
-            .filter(targetDep -> targetDep instanceof AndroidTarget)
-            .map(targetDep -> resRule((AndroidTarget) targetDep))
-            .collect(Collectors.toSet()));
+    libraryDeps.addAll(resources(target.getTargetDeps(false)));
+    libraryDeps.addAll(resources(target.getTargetExportedDeps(false)));
 
     List<String> libraryAptDeps = new ArrayList<>();
     libraryAptDeps.addAll(externalApt(target.getExternalAptDeps(false)));
@@ -54,6 +48,7 @@ public final class AndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
     Set<String> libraryExportedDeps = new HashSet<>();
     libraryExportedDeps.addAll(external(target.getExternalExportedDeps(false)));
     libraryExportedDeps.addAll(targets(target.getTargetExportedDeps(false)));
+    libraryExportedDeps.addAll(aidlRuleNames);
 
     List<String> testTargets = new ArrayList<>();
     if (target.getRobolectricEnabled() && !target.getTest().getSources().isEmpty()) {
@@ -80,7 +75,6 @@ public final class AndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
             .sourceCompatibility(target.getSourceCompatibility())
             .targetCompatibility(target.getTargetCompatibility())
             .testTargets(testTargets)
-            .exportedDeps(aidlRuleNames)
             .excludes(appClass != null ? ImmutableSet.of(appClass) : ImmutableSet.of())
             .generateR2(target.getGenerateR2())
             .options(target.getMain().getCustomOptions());

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/ExopackageAndroidLibraryRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/ExopackageAndroidLibraryRuleComposer.java
@@ -31,8 +31,9 @@ public final class ExopackageAndroidLibraryRuleComposer extends AndroidBuckRuleC
     deps.add(":" + buildConfig(target));
 
     Set<String> libraryAptDeps = new LinkedHashSet<>();
-    libraryAptDeps.addAll(externalApt(target.getApt().getExternalJarDeps()));
-    libraryAptDeps.addAll(targetsApt(target.getApt().getTargetDeps()));
+
+    libraryAptDeps.addAll(externalApt(target.getExternalAptDeps(false)));
+    libraryAptDeps.addAll(targetsApt(target.getTargetAptDeps(false)));
 
     Set<String> providedDeps = new LinkedHashSet<>();
     providedDeps.add(D8Util.RT_STUB_JAR_RULE);

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/java/JavaAnnotationProcessorRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/java/JavaAnnotationProcessorRuleComposer.java
@@ -1,5 +1,7 @@
 package com.uber.okbuck.composer.java;
 
+import static com.uber.okbuck.core.dependency.ExternalDependency.filterJar;
+
 import com.google.common.collect.ImmutableSet;
 import com.uber.okbuck.composer.jvm.JvmBuckRuleComposer;
 import com.uber.okbuck.core.model.base.RuleType;
@@ -33,7 +35,7 @@ public class JavaAnnotationProcessorRuleComposer extends JvmBuckRuleComposer {
         .map(
             scope -> {
               ImmutableSet.Builder<String> depsBuilder = new ImmutableSet.Builder<>();
-              depsBuilder.addAll(externalApt(scope.getExternalJarDeps()));
+              depsBuilder.addAll(externalApt(filterJar(scope.getExternalDeps())));
               depsBuilder.addAll(targetsApt(scope.getTargetDeps()));
 
               return new JavaAnnotationProcessorRule()

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/java/LocalPrebuiltRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/java/LocalPrebuiltRuleComposer.java
@@ -3,7 +3,6 @@ package com.uber.okbuck.composer.java;
 import static com.uber.okbuck.core.dependency.BaseExternalDependency.AAR;
 import static com.uber.okbuck.core.dependency.BaseExternalDependency.JAR;
 
-import com.google.common.collect.ImmutableList;
 import com.uber.okbuck.composer.jvm.JvmBuckRuleComposer;
 import com.uber.okbuck.core.dependency.ExternalDependency;
 import com.uber.okbuck.core.model.base.RuleType;
@@ -45,20 +44,16 @@ public class LocalPrebuiltRuleComposer extends JvmBuckRuleComposer {
                 source = null;
               }
 
-              ImmutableList.Builder<Rule> rulesBuilder = ImmutableList.builder();
-              rulesBuilder.add(
-                  new NativePrebuilt()
-                      .prebuiltType(ruleType.getProperties().get(0))
-                      .prebuilt(dependency.getDependencyFileName())
-                      .mavenCoords(dependency.getMavenCoords())
-                      .enableJetifier(dependency.enableJetifier())
-                      .source(source)
-                      .ruleType(ruleType.getBuckName())
-                      .name(dependency.getTargetName()));
-
-              return rulesBuilder.build();
+              return new NativePrebuilt()
+                  .prebuiltType(ruleType.getProperties().get(0))
+                  .prebuilt(dependency.getDependencyFileName())
+                  .mavenCoords(dependency.getMavenCoords())
+                  .enableJetifier(dependency.enableJetifier())
+                  .source(source)
+                  .ruleType(ruleType.getBuckName())
+                  .deps(dependency.getDeps())
+                  .name(dependency.getTargetName());
             })
-        .flatMap(Collection::stream)
         .collect(Collectors.toList());
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/java/PrebuiltRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/java/PrebuiltRuleComposer.java
@@ -45,8 +45,10 @@ public class PrebuiltRuleComposer extends JvmBuckRuleComposer {
                   .getRealSourceFile()
                   .ifPresent(file -> rule.sourcesSha256(DependencyUtils.shaSum256(file)));
 
-              rule.name(dependency.getTargetName());
-              rule.ruleType(RuleType.PREBUILT.getBuckName());
+              rule.ruleType(RuleType.PREBUILT.getBuckName())
+                  .deps(external(dependency.getDeps()))
+                  .name(dependency.getTargetName());
+
               return rule;
             })
         .collect(Collectors.toList());

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyCache.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyCache.java
@@ -1,8 +1,8 @@
 package com.uber.okbuck.core.dependency;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.uber.okbuck.core.manager.DependencyManager;
-import com.uber.okbuck.core.model.base.Scope;
 import com.uber.okbuck.core.util.ProjectUtil;
 import com.uber.okbuck.extension.ExternalDependenciesExtension;
 import com.uber.okbuck.extension.JetifierExtension;
@@ -10,8 +10,6 @@ import com.uber.okbuck.extension.OkBuckExtension;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,13 +42,9 @@ public class DependencyCache {
     this.skipPrebuilt = skipPrebuilt;
 
     if (forcedConfiguration != null) {
-      Scope.builder(project)
-          .configuration(forcedConfiguration)
-          .build()
-          .getAllExternal()
+      build(forcedConfiguration)
           .forEach(
               dependency -> {
-                get(dependency);
                 forcedDeps.put(dependency.getVersionless(), dependency);
               });
     }
@@ -81,6 +75,10 @@ public class DependencyCache {
     return dependency;
   }
 
+  public final void addDependencies(Set<org.gradle.api.artifacts.ExternalDependency> dependencies) {
+    dependencyManager.addDependencies(dependencies);
+  }
+
   /**
    * Get the list of annotation processor classes provided by a dependency.
    *
@@ -90,7 +88,6 @@ public class DependencyCache {
   public Set<String> getAnnotationProcessors(ExternalDependency externalDependency) {
     ExternalDependency dependency =
         forcedDeps.getOrDefault(externalDependency.getVersionless(), externalDependency);
-    String key = dependency.getTargetName();
 
     try {
       String processors =
@@ -148,32 +145,40 @@ public class DependencyCache {
     return content;
   }
 
-  public Set<ExternalDependency> build(Configuration configuration) {
-    return build(Collections.singleton(configuration));
-  }
-
   /**
    * Use this method to populate dependency caches of tools/languages etc. This is not meant to be
    * used across multiple threads/gradle task executions which can run in parallel. This method is
    * fully synchronous.
    *
-   * @param configurations The set of configurations to materialize into the dependency cache
+   * @param configuration The configuration to materialize into the dependency cache
    */
-  private Set<ExternalDependency> build(Set<Configuration> configurations) {
+  public Set<ExternalDependency> build(Configuration configuration) {
     OkBuckExtension okBuckExtension = ProjectUtil.getOkBuckExtension(rootProject);
 
     ExternalDependenciesExtension externalDependenciesExtension =
         okBuckExtension.getExternalDependenciesExtension();
     JetifierExtension jetifierExtension = okBuckExtension.getJetifierExtension();
 
-    return configurations
+    dependencyManager.addDependencies(
+        configuration
+            .getAllDependencies()
+            .stream()
+            .filter(i -> i instanceof org.gradle.api.artifacts.ExternalDependency)
+            .map(i -> (org.gradle.api.artifacts.ExternalDependency) i)
+            .collect(Collectors.toSet()));
+
+    return DependencyUtils.resolveExternal(
+            rootProject, configuration, externalDependenciesExtension, jetifierExtension)
         .stream()
-        .map(
-            configuration ->
-                DependencyUtils.resolveExternal(
-                    rootProject, configuration, externalDependenciesExtension, jetifierExtension))
-        .flatMap(Collection::stream)
         .map(this::get)
         .collect(Collectors.toSet());
+  }
+
+  private Set<ExternalDependency> build(String configuration) {
+    Configuration useful = DependencyUtils.useful(configuration, rootProject);
+
+    Preconditions.checkNotNull(useful);
+
+    return build(useful);
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyFactory.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyFactory.java
@@ -89,21 +89,21 @@ public final class DependencyFactory {
   }
 
   /**
-   * Returns a versionless dependency from the given gradle dependency.
+   * Returns a set of versionless dependencies from the given gradle dependency.
    *
    * @param dependency gradle dependency
    * @return VersionlessDependency object
    */
   public static Set<VersionlessDependency> fromDependency(
       org.gradle.api.artifacts.ExternalDependency dependency) {
-    VersionlessDependency.Builder vDependency =
+    VersionlessDependency.Builder vDependencyBuilder =
         VersionlessDependency.builder().setName(dependency.getName());
 
     String group = dependency.getGroup();
     if (group == null) {
-      vDependency.setGroup(LOCAL_GROUP);
+      vDependencyBuilder.setGroup(LOCAL_GROUP);
     } else {
-      vDependency.setGroup(group);
+      vDependencyBuilder.setGroup(group);
     }
 
     if (dependency.getArtifacts().size() > 0) {
@@ -112,19 +112,19 @@ public final class DependencyFactory {
           .stream()
           .map(
               dependencyArtifact ->
-                  vDependency
+                  vDependencyBuilder
                       .setClassifier(Optional.ofNullable(dependencyArtifact.getClassifier()))
                       .build())
           .collect(Collectors.toSet());
     } else {
       Set<VersionlessDependency> dependencies = new HashSet<>();
-      dependencies.add(vDependency.build());
+      dependencies.add(vDependencyBuilder.build());
       return dependencies;
     }
   }
 
   /**
-   * Returns a versionless dependency from the given gradle resolved dependency.
+   * Returns a set of versionless dependency from the given gradle resolved dependency.
    *
    * @param dependency gradle dependency
    * @return VersionlessDependency object

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/ExternalDependency.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/ExternalDependency.java
@@ -16,6 +16,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.gradle.api.artifacts.Dependency;
 
@@ -191,5 +192,19 @@ public class ExternalDependency {
 
     this.enableJetifier = jetifierExtension.shouldJetify(group, name, getPackaging());
     this.cachePath = Paths.get(externalDependenciesExtension.getCache());
+  }
+
+  public static Set<ExternalDependency> filterAar(Set<ExternalDependency> dependencies) {
+    return dependencies
+        .stream()
+        .filter(dependency -> dependency.getPackaging().equals(AAR))
+        .collect(Collectors.toSet());
+  }
+
+  public static Set<ExternalDependency> filterJar(Set<ExternalDependency> dependencies) {
+    return dependencies
+        .stream()
+        .filter(dependency -> dependency.getPackaging().equals(JAR))
+        .collect(Collectors.toSet());
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/ExternalDependency.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/ExternalDependency.java
@@ -12,8 +12,10 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.gradle.api.artifacts.Dependency;
 
@@ -27,8 +29,8 @@ public class ExternalDependency {
   private final BaseExternalDependency base;
   private final Path cachePath;
 
-  @Nullable private Path realSourceFilePath;
   private boolean enableJetifier;
+  private Set<ExternalDependency> dependencies = new HashSet<>();
 
   public static Comparator<ExternalDependency> compareByName =
       (o1, o2) ->
@@ -145,6 +147,14 @@ public class ExternalDependency {
   /** Returns true if this dependency needs to be jetified. */
   public boolean enableJetifier() {
     return enableJetifier;
+  }
+
+  public void setDeps(Set<ExternalDependency> dependencies) {
+    this.dependencies = dependencies;
+  }
+
+  public Set<ExternalDependency> getDeps() {
+    return dependencies;
   }
 
   String getSourceFileNameFrom(String prebuiltName) {

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/android/ExoPackageScope.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/android/ExoPackageScope.java
@@ -105,7 +105,7 @@ public class ExoPackageScope extends Scope {
           }
 
           Optional<ExternalDependency> externalDepOptional =
-              base.getAllExternal()
+              base.getExternalDeps(false)
                   .stream()
                   .filter(
                       dependency -> {
@@ -119,10 +119,10 @@ public class ExoPackageScope extends Scope {
                   .findFirst();
 
           if (externalDepOptional.isPresent()) {
-            getAllExternal().add(externalDepOptional.get());
+            this.external.add(externalDepOptional.get());
           } else {
             Optional<Target> variantDepOptional =
-                base.getTargetDeps()
+                base.getTargetDeps(false)
                     .stream()
                     .filter(
                         variant -> {
@@ -135,7 +135,7 @@ public class ExoPackageScope extends Scope {
                         })
                     .findFirst();
 
-            variantDepOptional.ifPresent(target -> getTargetDeps().add(target));
+            variantDepOptional.ifPresent(targetDeps::add);
           }
         });
   }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/base/Scope.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/base/Scope.java
@@ -1,6 +1,5 @@
 package com.uber.okbuck.core.model.base;
 
-import static com.uber.okbuck.core.dependency.BaseExternalDependency.AAR;
 import static com.uber.okbuck.core.dependency.BaseExternalDependency.JAR;
 
 import com.android.build.api.attributes.VariantAttr;
@@ -23,6 +22,7 @@ import com.uber.okbuck.extension.OkBuckExtension;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -38,6 +38,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.DependencySet;
+import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
@@ -47,8 +48,6 @@ import org.gradle.api.specs.Spec;
 
 public class Scope {
 
-  private static final String EMPTY_GROUP = "----empty----";
-
   private final Set<String> javaResources;
   private final Set<String> sources;
   @Nullable private final Configuration configuration;
@@ -56,8 +55,8 @@ public class Scope {
   private final Map<String, List<String>> customOptions;
   protected final Project project;
 
-  private final Set<Target> targetDeps = new HashSet<>();
-  private final Set<ExternalDependency> external = new HashSet<>();
+  protected final Set<Target> targetDeps = new HashSet<>();
+  protected final Set<ExternalDependency> external = new HashSet<>();
 
   @Nullable private Set<String> annotationProcessors;
 
@@ -71,10 +70,6 @@ public class Scope {
 
   public Map<String, List<String>> getCustomOptions() {
     return customOptions;
-  }
-
-  public final Set<ExternalDependency> getAllExternal() {
-    return external;
   }
 
   /** Used to filter out only project dependencies when resolving a configuration. */
@@ -120,25 +115,79 @@ public class Scope {
         ProjectUtil.getDependencyCache(project));
   }
 
-  public final Set<Target> getTargetDeps() {
-    return targetDeps;
+  public Set<Target> getTargetDeps(boolean firstLevel) {
+    OkBuckExtension okBuckExtension = ProjectUtil.getOkBuckExtension(project);
+    ExternalDependenciesExtension externalDependenciesExtension =
+        okBuckExtension.getExternalDependenciesExtension();
+
+    if (configuration != null && firstLevel) {
+      Set<String> firstLevelProjects =
+          configuration
+              .getAllDependencies()
+              .withType(ProjectDependency.class)
+              .stream()
+              .map(dependency -> dependency.getDependencyProject().getPath())
+              .collect(Collectors.toSet());
+
+      return targetDeps
+          .stream()
+          .filter(target -> firstLevelProjects.contains(target.getProject().getPath()))
+          .collect(Collectors.toSet());
+    } else {
+      return targetDeps;
+    }
   }
 
-  public Set<ExternalDependency> getExternalDeps() {
-    return getAllExternal().stream().map(depCache::get).collect(Collectors.toSet());
+  public final Set<Target> getTargetDeps() {
+    OkBuckExtension okBuckExtension = ProjectUtil.getOkBuckExtension(project);
+    ExternalDependenciesExtension externalDependenciesExtension =
+        okBuckExtension.getExternalDependenciesExtension();
+
+    return getTargetDeps(externalDependenciesExtension.exportedDepsEnabled());
+  }
+
+  public Set<ExternalDependency> getExternalDeps(boolean firstLevel) {
+    if (configuration != null && firstLevel) {
+      Set<VersionlessDependency> firstLevelDependencies =
+          configuration
+              .getAllDependencies()
+              .withType(org.gradle.api.artifacts.ExternalDependency.class)
+              .stream()
+              .map(DependencyFactory::fromDependency)
+              .flatMap(Collection::stream)
+              .collect(Collectors.toSet());
+
+      // TODO: Handle first level local deps correctly
+
+      return external
+          .stream()
+          .map(depCache::get)
+          .filter(
+              dependency -> {
+                VersionlessDependency vDependency = dependency.getVersionless();
+                if (vDependency.group().equals(DependencyFactory.LOCAL_GROUP)) {
+                  return true;
+                }
+                return firstLevelDependencies.contains(vDependency);
+              })
+          .collect(Collectors.toSet());
+    } else {
+      return external.stream().map(depCache::get).collect(Collectors.toSet());
+    }
+  }
+
+  public final Set<ExternalDependency> getExternalDeps() {
+    OkBuckExtension okBuckExtension = ProjectUtil.getOkBuckExtension(project);
+    ExternalDependenciesExtension externalDependenciesExtension =
+        okBuckExtension.getExternalDependenciesExtension();
+
+    return getExternalDeps(externalDependenciesExtension.exportedDepsEnabled());
   }
 
   public Set<ExternalDependency> getExternalJarDeps() {
     return getExternalDeps()
         .stream()
         .filter(dependency -> dependency.getPackaging().equals(JAR))
-        .collect(Collectors.toSet());
-  }
-
-  public Set<ExternalDependency> getExternalAarDeps() {
-    return getExternalDeps()
-        .stream()
-        .filter(dependency -> dependency.getPackaging().equals(AAR))
         .collect(Collectors.toSet());
   }
 
@@ -153,41 +202,14 @@ public class Scope {
     }
 
     if (annotationProcessors == null) {
-      Set<VersionlessDependency> firstLevelDependencies =
-          configuration
-              .getAllDependencies()
-              .stream()
-              .map(
-                  dependency -> {
-                    String group =
-                        dependency.getGroup() == null ? EMPTY_GROUP : dependency.getGroup();
-                    return VersionlessDependency.builder()
-                        .setGroup(group)
-                        .setName(dependency.getName())
-                        .build();
-                  })
-              .collect(Collectors.toSet());
-
       annotationProcessors =
           Streams.concat(
-                  getExternalDeps()
+                  getExternalDeps(true)
                       .stream()
-                      .filter(
-                          dependency ->
-                              firstLevelDependencies.contains(dependency.getVersionless()))
                       .map(depCache::getAnnotationProcessors)
                       .flatMap(Set::stream),
-                  targetDeps
+                  getTargetDeps(true)
                       .stream()
-                      .filter(
-                          target -> {
-                            VersionlessDependency versionless =
-                                VersionlessDependency.builder()
-                                    .setGroup((String) target.getProject().getGroup())
-                                    .setName(target.getProject().getName())
-                                    .build();
-                            return firstLevelDependencies.contains(versionless);
-                          })
                       .map(
                           target -> {
                             OkBuckExtension okBuckExtension = target.getOkbuck();
@@ -298,6 +320,15 @@ public class Scope {
   }
 
   private void extractConfiguration(Configuration configuration) {
+
+    depCache.addDependencies(
+        configuration
+            .getAllDependencies()
+            .stream()
+            .filter(i -> i instanceof org.gradle.api.artifacts.ExternalDependency)
+            .map(i -> (org.gradle.api.artifacts.ExternalDependency) i)
+            .collect(Collectors.toSet()));
+
     Set<ResolvedArtifactResult> jarArtifacts =
         getArtifacts(configuration, PROJECT_FILTER, ImmutableList.of("jar"));
 
@@ -369,12 +400,13 @@ public class Scope {
                             + ". Please move dependency: %s inside %s",
                         artifact.getFile(), project.getRootProject().getProjectDir()));
               }
-              external.add(
+              ExternalDependency localExternalDependency =
                   DependencyFactory.fromLocal(
                       artifact.getFile(),
                       sourcesArtifact != null ? sourcesArtifact.getFile() : null,
                       externalDependenciesExtension,
-                      jetifierExtension));
+                      jetifierExtension);
+              external.add(localExternalDependency);
 
             } catch (IOException e) {
               throw new RuntimeException(e);

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
@@ -19,7 +19,9 @@ import com.uber.okbuck.core.manager.TransformManager;
 import com.uber.okbuck.core.model.base.ProjectType;
 import com.uber.okbuck.extension.OkBuckExtension;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -27,16 +29,28 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FilenameUtils;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.SelfResolvingDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.artifacts.result.ArtifactResult;
 import org.gradle.api.artifacts.result.ComponentArtifactsResult;
+import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.component.Artifact;
+import org.gradle.api.internal.artifacts.result.DefaultResolvedArtifactResult;
 import org.gradle.api.plugins.GroovyPlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.plugins.scala.ScalaPlugin;
+import org.gradle.api.specs.Specs;
+import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.jvm.JvmLibrary;
 import org.gradle.language.base.artifact.SourcesArtifact;
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper;
@@ -205,5 +219,98 @@ public final class ProjectUtil {
     return !DependencyUtils.isWhiteListed(dependencyFile)
         && ImmutableList.of(JAR, AAR)
             .contains(FilenameUtils.getExtension(dependencyFile.getName()));
+  }
+
+  /**
+   * @param project
+   * @return - A list of all binary dependencies, including transitives of both binary dependencies
+   *     and project dependencies
+   */
+  @SuppressWarnings({"unchecked", "NullAway"})
+  private static List<ExtDependency> buildExternalDependencies(
+      Project project, Configuration conf) {
+    Map<String, ExtDependency> externalDependenciesById = new HashMap<>();
+
+    List<ComponentIdentifier> binaryDependencies = new ArrayList<>();
+    for (DependencyResult dep : conf.getIncoming().getResolutionResult().getAllDependencies()) {
+      if (dep instanceof ResolvedDependencyResult
+          && dep.getRequested() instanceof DefaultModuleComponentSelector)
+        binaryDependencies.add(((ResolvedDependencyResult) dep).getSelected().getId());
+    }
+
+    List<String> binaryDependenciesAsStrings = new ArrayList<>();
+    for (ComponentIdentifier binaryDependency : binaryDependencies)
+      binaryDependenciesAsStrings.add(binaryDependency.toString());
+
+    Set<ComponentArtifactsResult> artifactsResults =
+        project
+            .getDependencies()
+            .createArtifactResolutionQuery()
+            .forComponents(binaryDependencies)
+            .withArtifacts(JvmLibrary.class, SourcesArtifact.class)
+            .execute()
+            .getResolvedComponents();
+
+    for (ResolvedArtifact artifact :
+        conf.getResolvedConfiguration()
+            .getLenientConfiguration()
+            .getArtifacts(Specs.SATISFIES_ALL)) {
+      ModuleVersionIdentifier id = artifact.getModuleVersion().getId();
+      if (binaryDependenciesAsStrings.contains(id.toString())) {
+        externalDependenciesById.put(
+            id.toString(), new ExtDependency().setFile(artifact.getFile()).setModuleVersion(id));
+      }
+    }
+
+    for (ComponentArtifactsResult artifactResult : artifactsResults) {
+      ExtDependency externalDependency =
+          externalDependenciesById.get(artifactResult.getId().toString());
+      for (ArtifactResult sourcesResult : artifactResult.getArtifacts(SourcesArtifact.class)) {
+        if (sourcesResult instanceof DefaultResolvedArtifactResult)
+          externalDependency.setSource(((DefaultResolvedArtifactResult) sourcesResult).getFile());
+      }
+    }
+
+    // this grabs "local file dependencies" (e.g. gradleApi(), localGroovy())
+    for (Dependency dependency : conf.getAllDependencies()) {
+      if (dependency instanceof SelfResolvingDependency
+          && !(dependency instanceof ProjectDependency)) {
+        Set<File> resolvedFiles = ((SelfResolvingDependency) dependency).resolve();
+
+        for (File resolvedFile : resolvedFiles) {
+          // these type of dependencies do not have a module version identifier, the file path is
+          // unique enough
+          externalDependenciesById.put(
+              resolvedFile.getAbsolutePath(), new ExtDependency().setFile(resolvedFile));
+        }
+      }
+    }
+
+    // must create new list because Map.values() is not Serializable
+    return new ArrayList<>(externalDependenciesById.values());
+  }
+
+  @SuppressWarnings({"unchecked", "NullAway"})
+  private static class ExtDependency {
+    private File file;
+    private ModuleVersionIdentifier id;
+    private File source;
+
+    ExtDependency() {}
+
+    ExtDependency setFile(File file) {
+      this.file = file;
+      return this;
+    }
+
+    ExtDependency setModuleVersion(ModuleVersionIdentifier id) {
+      this.id = id;
+      return this;
+    }
+
+    ExtDependency setSource(File source) {
+      this.source = source;
+      return this;
+    }
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/ExternalDependenciesExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/ExternalDependenciesExtension.java
@@ -18,6 +18,9 @@ public class ExternalDependenciesExtension {
   /** Specifies what resolution action to use for external dependencies. */
   @Input private ResolutionAction resolutionAction = ResolutionAction.ALL;
 
+  /** Specifies whether to enable exported_deps for external dependencies or not. */
+  @Input private boolean enableExportedDeps = false;
+
   /**
    * Stores the dependencies which are allowed to have more than 1 version. This is needed for few
    * dependencies like robolectric runtime deps.
@@ -82,5 +85,9 @@ public class ExternalDependenciesExtension {
 
   public boolean shouldDownloadInBuck() {
     return downloadInBuck;
+  }
+
+  public boolean exportedDepsEnabled() {
+    return enableExportedDeps;
   }
 }

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/android/ResourceRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/android/ResourceRule.rocker.raw
@@ -4,6 +4,7 @@ String pkg,
 Collection res,
 String projectRes,
 Collection assets,
+Collection exportedDeps,
 boolean resourceUnion)
 @com.uber.okbuck.template.base.BuckRule.template() -> {
     package = '@pkg',
@@ -23,6 +24,13 @@ boolean resourceUnion)
         ('@a', '**'),
     }
     ]),
+}
+@if (valid(exportedDeps)) {
+    exported_deps = [
+    @for (dep : sorted(exportedDeps)) {
+        '@dep',
+    }
+    ],
 }
 @if (resourceUnion) {
     resource_union = True,

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/OkbuckPrebuilt.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/OkbuckPrebuilt.rocker.raw
@@ -8,11 +8,15 @@ def okbuck_prebuilt(
     maven_coords,
     sha256,
     sources_sha256=None,
+    deps=None,
     visibility=None,
     enable_jetifier=False,
     ):
     if visibility == None:
         visibility = ['PUBLIC']
+
+    if deps == None:
+        deps = []
 
     prebuilt_type = maven_coords.split(':')[2]
 
@@ -49,6 +53,7 @@ def okbuck_prebuilt(
             aar = ':' + prebuilt_file_name,
             source_jar = ':' + prebuilt_sources_file_name if sources_maven_coords != None else None,
             maven_coords = maven_coords,
+            deps = deps,
             visibility = visibility,
             enable_jetifier = enable_jetifier,
         )
@@ -58,6 +63,7 @@ def okbuck_prebuilt(
             binary_jar = ':' + prebuilt_file_name,
             source_jar = ':' + prebuilt_sources_file_name if sources_maven_coords != None else None,
             maven_coords = maven_coords,
+            deps = deps,
             visibility = visibility,
             enable_jetifier = enable_jetifier,
         )

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/java/Prebuilt.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/java/Prebuilt.rocker.raw
@@ -12,6 +12,13 @@ boolean enableJetifier,
 @if (valid(sourcesSha256)) {
     sources_sha256 = '@sourcesSha256',
 }
+@if (valid(deps)) {
+    deps = [
+    @for (dep : sorted(deps)) {
+        '@dep',
+    }
+    ],
+}
 @if (enableJetifier) {
     enable_jetifier = True,
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -71,6 +71,7 @@ def external = [
         avroIpc         : "org.apache.avro:avro-ipc:1.7.7",
         avroIpcTests    : "org.apache.avro:avro-ipc:1.7.7:tests",
         saxon           : "net.sf.saxon:Saxon-HE:9.7.0-15",
+        scalaLibrary    : "org.scala-lang:scala-library:2.12.4"
 ]
 
 def lint = [
@@ -98,10 +99,12 @@ def test = [
         kotlinTest    : "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}",
         mockito       : "org.mockito:mockito-core:2.15.0",
         robolectric   : "org.robolectric:robolectric:3.8",
+        scalaTest     : "org.scalatest:scalatest_2.12:3.0.5"
 ]
 
 ext.config = [
-        "build": buildConfig,
+        "build":    buildConfig,
+        "versions": versions
 ]
 
 ext.deps = [
@@ -111,5 +114,4 @@ ext.deps = [
         "external": external,
         "lint"    : lint,
         "test"    : test,
-        "versions": versions
 ]

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -104,7 +104,6 @@ def test = [
 
 ext.config = [
         "build":    buildConfig,
-        "versions": versions
 ]
 
 ext.deps = [
@@ -114,4 +113,5 @@ ext.deps = [
         "external": external,
         "lint"    : lint,
         "test"    : test,
+        "versions": versions,
 ]

--- a/libraries/parcelable/build.gradle
+++ b/libraries/parcelable/build.gradle
@@ -5,3 +5,7 @@ android {
 		consumerProguardFiles "proguard.txt"
 	}
 }
+
+dependencies {
+    api deps.androidx.material
+}

--- a/libraries/scalalibrary/build.gradle
+++ b/libraries/scalalibrary/build.gradle
@@ -4,10 +4,10 @@ plugins {
 }
 
 dependencies {
-    compile "org.scala-lang:scala-library:2.12.4"
+    compile deps.external.scalaLibrary
 
-    testCompile "org.scalatest:scalatest_2.12:3.0.5"
-    testCompile "junit:junit:4.12"
+    testCompile deps.test.scalaTest
+    testCompile deps.test.junit
 }
 
 mainClassName = "com.uber.okbuck.scala.example.Hello"


### PR DESCRIPTION
To make generated buck files small and less verbose we can use `exported_deps` for api dependencies. deps of prebuilts are exported by default (i.e dependees of a prebuilt will also get prebuilt's dependencies in it's compile classpath). 

To enable this make the below changes in okbuck extension:
```
okbuck {
    externalDependencies {
        resolutionAction = "latest"
        enableExportedDeps = true
    }
}
```

Note: this only works when `resolutionAction` is either `latest` or `single`.


example generated buck files:
```
// in .okbuck/ext/androidx/activity/BUCK
load('//.okbuck/defs:okbuck_prebuilt.bzl', 'okbuck_prebuilt')

okbuck_prebuilt(
    name = 'activity.aar',
    maven_coords = 'androidx.activity:activity:aar:1.0.0-alpha04',
    sha256 = '4a2c0a2e53933075fa6979b8921a8c7047ec60d5e3906d774f77bd598842aad9',
    sources_sha256 = '6127d87d0d7402172341c6c30591fdb05f7c1e63ec29e79be88d1f8fe46ca762',
    deps = [
        '//3rdparty/jvm/androidx/annotation:annotation.jar',
        '//3rdparty/jvm/androidx/core:core.aar',
        '//3rdparty/jvm/androidx/lifecycle:lifecycle-runtime.aar',
        '//3rdparty/jvm/androidx/lifecycle:lifecycle-viewmodel.aar',
        '//3rdparty/jvm/androidx/savedstate:savedstate-bundle.aar',
    ],
)


// in .okbuck/ext/androidx/lifecycle/BUCK
load('//.okbuck/defs:okbuck_prebuilt.bzl', 'okbuck_prebuilt')

okbuck_prebuilt(
    name = 'lifecycle-runtime.aar',
    maven_coords = 'androidx.lifecycle:lifecycle-runtime:aar:2.0.0',
    sha256 = 'e4afc9e636183f6f3e0edf1cf46121a492ffd2c673075bb07f55c7a99dd43cfb',
    sources_sha256 = '472d99cf093b3b65d24a5707138ce51b160eb81a0ed59095ca8c8e0883ab1524',
    deps = [
        '//3rdparty/jvm/androidx/annotation:annotation.jar',
        '//3rdparty/jvm/androidx/arch/core:core-common.jar',
        '//3rdparty/jvm/androidx/lifecycle:lifecycle-common.jar',
    ],
)

// in an android library buck file
android_library (
    name = 'src_release',
    deps = [
         '//.okbuck/ext/androidx/activity:activity.aar'
    ]
```

In the above android_library we don't need to specify `lifecycle-runtime.aar` or `lifecycle-common.jar` as a dependency since that would be coming transitively. 

To enable this change, make sure you have pulled in https://github.com/facebook/buck/pull/2247 PR on the buck side. 
