### PR TITLE
Cleanup versionless resolution actions handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,35 +211,7 @@ okbuck {
     }
 
     externalDependencies {
-        versionless = true
-        allowLatestVersion = [
-            "com.google.auto.value:auto-value",
-            "com.google.code.findbugs:jsr305",
-            "org.ow2.asm:asm",
-            "org.ow2.asm:asm-commons",
-            "com.google.protobuf:protobuf-java",
-            "commons-codec:commons-codec",
-            "com.google.errorprone:error_prone_annotations",
-            "com.google.auto:auto-common",
-            "com.google.guava:guava",
-            "org.apache.httpcomponents:httpcore",
-            "org.jetbrains.kotlin:kotlin-stdlib",
-            "org.jetbrains.kotlin:kotlin-reflect",
-            "org.jetbrains.kotlin:kotlin-stdlib-common",
-            "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-            "org.ow2.asm:asm-tree",
-            "org.apache.httpcomponents:httpclient",
-            "org.bouncycastle:bcprov-jdk15on",
-            "commons-logging:commons-logging",
-            "com.squareup:javapoet",
-            "org.checkerframework:checker-compat-qual",
-            "com.google.code.gson:gson",
-            "org.apache.commons:commons-compress",
-            "org.apache.httpcomponents:httpmime",
-        ]
-        allowAllVersions = [
-            "org.robolectric:android-all",
-        ]
+        resolutionAction = "latest"
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -213,9 +213,6 @@ okbuck {
     externalDependencies {
         resolutionAction = "latest"
         allowAllVersions = [
-                "org.ow2.asm:asm",
-                "org.ow2.asm:asm-commons",
-                "com.google.guava:guava",
                 "org.robolectric:android-all",
         ]
     }

--- a/build.gradle
+++ b/build.gradle
@@ -212,6 +212,12 @@ okbuck {
 
     externalDependencies {
         resolutionAction = "latest"
+        allowAllVersions = [
+                "org.ow2.asm:asm",
+                "org.ow2.asm:asm-commons",
+                "com.google.guava:guava",
+                "org.robolectric:android-all",
+        ]
     }
 
     dependencies {

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/ExternalDependency.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/ExternalDependency.java
@@ -50,7 +50,7 @@ public class ExternalDependency {
   }
 
   /**
-   * Retruns the maven coordinates used for version validation. This excludes the classifier and
+   * Return the maven coordinates used for version validation. This excludes the classifier and
    * packaging attributes
    */
   public String getMavenCoordsForValidation() {

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/DependencyManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/DependencyManager.java
@@ -82,7 +82,7 @@ public class DependencyManager {
   }
 
   private Map<VersionlessDependency, Collection<ExternalDependency>> filterDependencies() {
-    if (!externalDependenciesExtension.allowLatestEnabled()) {
+    if (!externalDependenciesExtension.useLatest()) {
       return originalDependencyMap.asMap();
     }
 
@@ -99,7 +99,7 @@ public class DependencyManager {
               if (value.size() == 1) {
                 // Already has one dependency, no need to resolve different versions.
                 filteredDependencyMapBuilder.put(key, value);
-              } else if (externalDependenciesExtension.isAllowLatestFor(key)) {
+              } else if (externalDependenciesExtension.useLatest(key)) {
                 dependenciesToResolveBuilder.addAll(value);
               } else {
                 filteredDependencyMapBuilder.put(key, value);
@@ -139,16 +139,9 @@ public class DependencyManager {
               .entrySet()
               .stream()
               .filter(entry -> entry.getValue().size() > 1)
+              .filter(entry -> !externalDependenciesExtension.isVersioned(entry.getKey()))
               .map(Map.Entry::getValue)
-              .filter(
-                  deps ->
-                      deps.stream()
-                              .map(ExternalDependency::getMavenCoordsForValidation)
-                              .collect(Collectors.toSet())
-                              .size()
-                          > 1)
               .flatMap(Collection::stream)
-              .filter(dependency -> !externalDependenciesExtension.isAllowedVersion(dependency))
               .collect(
                   Collectors.groupingBy(
                       dependency -> dependency.getVersionless().mavenCoords(),

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/ExternalDependenciesExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/ExternalDependenciesExtension.java
@@ -1,18 +1,11 @@
 package com.uber.okbuck.extension;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-import com.uber.okbuck.core.dependency.ExternalDependency;
 import com.uber.okbuck.core.dependency.VersionlessDependency;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import org.gradle.api.Project;
 import org.gradle.api.tasks.Input;
 
 public class ExternalDependenciesExtension {
@@ -22,79 +15,19 @@ public class ExternalDependenciesExtension {
   /** Specifies whether the external dependencies should be downloaded by buck or not. */
   @Input private boolean downloadInBuck = true;
 
-  /** Stores the dependencies which are allowed to have latest version. */
-  @Input private List<String> allowLatestVersion = new ArrayList<>();
+  /** Specifies what resolution action to use for external dependencies. */
+  @Input private ResolutionAction resolutionAction = ResolutionAction.ALL;
 
-  /** Stores the dependencies which are allowed to have more than 1 version. */
-  @Input private List<String> allowAllVersions = new ArrayList<>();
+  /**
+   * Stores the dependencies which are allowed to have more than 1 version. This is needed for few
+   * dependencies like robolectric runtime deps.
+   */
+  @Input
+  private List<String> allowAllVersions = Collections.singletonList("org.robolectric:android-all");
 
-  /** Stores the dependencies and their allowed versions */
-  @Input private Map<String, List<String>> allowSpecificVersions = new HashMap<>();
-
-  private boolean versionless = false;
-  private boolean allowLatestForAll = false;
-
-  @Nullable private Set<VersionlessDependency> allowLatestVersionSet;
   @Nullable private Set<VersionlessDependency> allowAllVersionsSet;
-  @Nullable private Map<VersionlessDependency, List<String>> allowedVersionsMap;
 
-  public ExternalDependenciesExtension(Project project) {
-    project.afterEvaluate(
-        evaluatedProject -> {
-          validateExtension();
-        });
-  }
-
-  private void validateExtension() {
-    Set<VersionlessDependency> allowLatest = getAllowLatestVersionSet();
-    Set<VersionlessDependency> allowAll = getAllowAllVersionsSet();
-    Set<VersionlessDependency> allowSpecific = getAllowSpecificVersionsMap().keySet();
-
-    checkIntersection(
-        Sets.intersection(allowLatest, allowAll), "allowLatestVersion", "allowAllVersions");
-    checkIntersection(
-        Sets.intersection(allowLatest, allowSpecific),
-        "allowLatestVersion",
-        "allowSpecificVersions");
-    checkIntersection(
-        Sets.intersection(allowAll, allowSpecific), "allowAllVersions", "allowSpecificVersions");
-  }
-
-  private static void checkIntersection(
-      Sets.SetView<VersionlessDependency> intersect, String setA, String setB) {
-    String intersectErrorString =
-        intersect
-            .stream()
-            .map(VersionlessDependency::mavenCoords)
-            .collect(Collectors.joining("\n"));
-
-    Preconditions.checkArgument(
-        intersect.size() == 0,
-        String.format(
-            "'%s' found in both '%s' & '%s', please remove from one of them.",
-            intersectErrorString, setA, setB));
-  }
-
-  private synchronized Map<VersionlessDependency, List<String>> getAllowSpecificVersionsMap() {
-    if (allowedVersionsMap == null) {
-      allowedVersionsMap =
-          allowSpecificVersions
-              .entrySet()
-              .stream()
-              .peek(
-                  entry ->
-                      Preconditions.checkArgument(
-                          entry.getValue().size() > 1,
-                          String.format(
-                              "%s should have more than one versions specified in 'allowSpecificVersions'",
-                              entry.getKey())))
-              .collect(
-                  Collectors.toMap(
-                      entry -> VersionlessDependency.fromMavenCoords(entry.getKey()),
-                      Map.Entry::getValue));
-    }
-    return allowedVersionsMap;
-  }
+  public ExternalDependenciesExtension() {}
 
   private synchronized Set<VersionlessDependency> getAllowAllVersionsSet() {
     if (allowAllVersionsSet == null) {
@@ -107,87 +40,40 @@ public class ExternalDependenciesExtension {
     return allowAllVersionsSet;
   }
 
-  private synchronized Set<VersionlessDependency> getAllowLatestVersionSet() {
-    if (allowLatestVersionSet == null) {
-      allowLatestVersionSet =
-          allowLatestVersion
-              .stream()
-              .map(VersionlessDependency::fromMavenCoords)
-              .collect(ImmutableSet.toImmutableSet());
-    }
-    return allowLatestVersionSet;
+  public boolean useLatest() {
+    return resolutionAction.equals(ResolutionAction.LATEST);
   }
 
-  /**
-   * Returns whether versionless is enabled or not. This is a global flag to turn on/off
-   * versionless.
-   *
-   * @return boolean stating above.
-   */
+  public boolean useLatest(VersionlessDependency versionlessDependency) {
+    if (getAllowAllVersionsSet().contains(versionlessDependency)) {
+      return false;
+    }
+
+    return useLatest();
+  }
+
+  public boolean useSingle() {
+    return resolutionAction.equals(ResolutionAction.SINGLE);
+  }
+
+  public boolean useSingle(VersionlessDependency versionlessDependency) {
+    if (getAllowAllVersionsSet().contains(versionlessDependency)) {
+      return false;
+    }
+
+    return useSingle();
+  }
+
   public boolean versionlessEnabled() {
-    return versionless;
+    return useLatest() || useSingle();
   }
 
-  /**
-   * Returns whether using latest version is enabled for any dependency.
-   *
-   * @return boolean stating above.
-   */
-  public boolean allowLatestEnabled() {
-    return allowLatestForAll || getAllowLatestVersionSet().size() > 0;
-  }
-
-  /**
-   * Checks if the latest version should be used for this dependency.
-   *
-   * @param versionlessDependency dependency to check.
-   * @return boolean stating above.
-   */
-  public boolean isAllowLatestFor(VersionlessDependency versionlessDependency) {
-    if (!versionless) {
-      return false;
-    }
-
-    return allowLatestForAll || getAllowLatestVersionSet().contains(versionlessDependency);
-  }
-
-  /**
-   * Checks whether the given dependency should be versioned or not.
-   *
-   * @param versionlessDependency dependency to check.
-   * @return boolean stating above.
-   */
   public boolean isVersioned(VersionlessDependency versionlessDependency) {
-    if (!versionlessEnabled()) {
+    if (getAllowAllVersionsSet().contains(versionlessDependency)) {
       return true;
     }
 
-    if (isAllowLatestFor(versionlessDependency)) {
-      return false;
-    }
-
-    return getAllowAllVersionsSet().contains(versionlessDependency)
-        || getAllowSpecificVersionsMap().containsKey(versionlessDependency);
-  }
-
-  /**
-   * Checks whether the given versioned dependency is allowed.
-   *
-   * @param dependency dependency to check.
-   * @return boolean stating above.
-   */
-  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-  public boolean isAllowedVersion(ExternalDependency dependency) {
-    if (!versionlessEnabled()) {
-      return true;
-    }
-
-    if (getAllowAllVersionsSet().contains(dependency.getVersionless())) {
-      return true;
-    }
-
-    List<String> allowedVersions = getAllowSpecificVersionsMap().get(dependency.getVersionless());
-    return allowedVersions != null && allowedVersions.contains(dependency.getVersion());
+    return !versionlessEnabled();
   }
 
   public String getCache() {

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
@@ -97,7 +97,8 @@ public class OkBuckExtension {
   private TransformExtension transformExtension = new TransformExtension();
   private LintExtension lintExtension;
   private JetifierExtension jetifierExtension;
-  private ExternalDependenciesExtension externalDependenciesExtension;
+  private ExternalDependenciesExtension externalDependenciesExtension =
+      new ExternalDependenciesExtension();
   private VisibilityExtension visibilityExtension = new VisibilityExtension();
   private RuleOverridesExtension ruleOverridesExtension;
 
@@ -106,7 +107,6 @@ public class OkBuckExtension {
     kotlinExtension = new KotlinExtension(project);
     lintExtension = new LintExtension(project);
     jetifierExtension = new JetifierExtension(project);
-    externalDependenciesExtension = new ExternalDependenciesExtension(project);
     ruleOverridesExtension = new RuleOverridesExtension(project);
   }
 

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/ResolutionAction.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/ResolutionAction.java
@@ -1,0 +1,18 @@
+package com.uber.okbuck.extension;
+
+public enum ResolutionAction {
+  // Use latest version of the external dependency
+  LATEST("latest"),
+
+  // Use all resolved versions of the external dependency
+  ALL("all"),
+
+  // Use single resolved version of the external dependency and fail if multiple versions are found
+  SINGLE("single");
+
+  private final String action;
+
+  ResolutionAction(String action) {
+    this.action = action;
+  }
+}

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/ResolutionAction.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/ResolutionAction.java
@@ -2,17 +2,11 @@ package com.uber.okbuck.extension;
 
 public enum ResolutionAction {
   // Use latest version of the external dependency
-  LATEST("latest"),
+  LATEST,
 
   // Use all resolved versions of the external dependency
-  ALL("all"),
+  ALL,
 
   // Use single resolved version of the external dependency and fail if multiple versions are found
-  SINGLE("single");
-
-  private final String action;
-
-  ResolutionAction(String action) {
-    this.action = action;
-  }
+  SINGLE;
 }


### PR DESCRIPTION
This allows for only the below resolution actions:

- latest
- all
- single (fails if finds multiple versions)

When using latest or single versionless names will be used for external dependencies.

Can also specify coordinates for deps whose all versions is to be allowed when in latest or single mode. for eg: roblectric runtime deps.

```
externalDependency {
    resolutionAction = latest
    allowAllVersions = [
        "org.robolectric:android-all",
        "com.guava:guava",
    ]
}
```
