### PR TITLE
Throw exception if a dep is not found in resolved dependency list when exported deps is enabled

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 // CI keeps gradle home cached based on the SHA of this file.
 // Update below to invalidate the cache.
-// Gradle Cache Version 1
+// Gradle Cache Version 2
 
 def versions = [
         androidPlugin      : "3.2.0",


### PR DESCRIPTION
If this happens that means that some deps are being substituted to a project dependency. Hence upon resolving just the external dependencies those substituted external dependencies might not be found in project's resolved dependency list. 