### PR TITLE
 Compose external dependency processors in external dependency's buck file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -215,6 +215,11 @@ okbuck {
         allowAllVersions = [
                 "org.robolectric:android-all",
         ]
+        autoValueConfigurations = [
+            "autoValueAnnotations",
+            "autoValueGson",
+            "autoValueParcel",
+        ]
     }
 
     dependencies {
@@ -243,8 +248,16 @@ okbuck {
     }
 }
 
+def autoValueDeps = [deps.apt.autoValue, deps.apt.autoValueAnnotations]
+def autoValueGsonDeps = autoValueDeps + [deps.apt.autoValueGson]
+def autoValueParcelDeps = autoValueDeps + [deps.apt.autoValueParcel]
+
 afterEvaluate {
     dependencies {
         toolsExtraDepCache deps.external.saxon
+
+        autoValueAnnotations autoValueDeps
+        autoValueGson autoValueGsonDeps
+        autoValueParcel autoValueParcelDeps
     }
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -99,7 +99,7 @@ task sourcesJar(type: Jar) {
     classifier = "sources"
 }
 
-def publishVersion = "0.48.1-LOCAL"
+def publishVersion = "0.47.1"
 group = "com.uber"
 version = publishVersion
 def siteUrl = "https://github.com/uber/okbuck"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -99,7 +99,7 @@ task sourcesJar(type: Jar) {
     classifier = "sources"
 }
 
-def publishVersion = "0.47.1"
+def publishVersion = "0.48.1-LOCAL"
 group = "com.uber"
 version = publishVersion
 def siteUrl = "https://github.com/uber/okbuck"

--- a/buildSrc/src/main/java/com/uber/okbuck/OkBuckGradlePlugin.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/OkBuckGradlePlugin.java
@@ -92,8 +92,8 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
   public final Set<String> exportedPaths = Sets.newConcurrentHashSet();
 
   public DependencyCache depCache;
-  public AnnotationProcessorCache annotationProcessorCache;
   public DependencyManager dependencyManager;
+  public AnnotationProcessorCache annotationProcessorCache;
   public LintManager lintManager;
   public KotlinManager kotlinManager;
   public ScalaManager scalaManager;
@@ -121,6 +121,13 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
 
     rootProject.afterEvaluate(
         rootBuckProject -> {
+          // Create autovalue extension configurations
+          Set<String> configs =
+              okbuckExt.getExternalDependenciesExtension().getAutoValueConfigurations();
+          for (String config : configs) {
+            rootBuckProject.getConfigurations().maybeCreate(config);
+          }
+
           // Create tasks
           Task setupOkbuck = rootBuckProject.getTasks().create("setupOkbuck");
           setupOkbuck.setGroup(GROUP);

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/java/JavaAnnotationProcessorRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/java/JavaAnnotationProcessorRuleComposer.java
@@ -30,8 +30,9 @@ public class JavaAnnotationProcessorRuleComposer extends JvmBuckRuleComposer {
         .sorted(
             (scope1, scope2) ->
                 scope1
-                    .getAnnotationProcessorsUID()
-                    .compareToIgnoreCase(scope2.getAnnotationProcessorsUID()))
+                    .getAnnotationProcessorPlugin()
+                    .pluginUID()
+                    .compareToIgnoreCase(scope2.getAnnotationProcessorPlugin().pluginUID()))
         .map(
             scope -> {
               ImmutableSet.Builder<String> depsBuilder = new ImmutableSet.Builder<>();
@@ -40,7 +41,7 @@ public class JavaAnnotationProcessorRuleComposer extends JvmBuckRuleComposer {
 
               return new JavaAnnotationProcessorRule()
                   .processorClasses(scope.getAnnotationProcessors())
-                  .name(getApPluginRuleName(scope.getAnnotationProcessorsUID()))
+                  .name(getApPluginRuleName(scope.getAnnotationProcessorPlugin()))
                   .deps(depsBuilder.build())
                   .ruleType(RuleType.JAVA_ANNOTATION_PROCESSOR.getBuckName());
             })

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/jvm/JvmBuckRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/jvm/JvmBuckRuleComposer.java
@@ -2,6 +2,7 @@ package com.uber.okbuck.composer.jvm;
 
 import com.uber.okbuck.OkBuckGradlePlugin;
 import com.uber.okbuck.composer.base.BuckRuleComposer;
+import com.uber.okbuck.core.annotation.JvmPlugin;
 import com.uber.okbuck.core.model.jvm.JvmTarget;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -26,28 +27,33 @@ public class JvmBuckRuleComposer extends BuckRuleComposer {
    * @param aps Annotation Processor plugin's UID
    * @return Set of java annotation processor plugin's rule paths.
    */
-  public static Set<String> getApPlugins(Set<String> aps) {
+  public static Set<String> getApPlugins(Set<JvmPlugin> aps) {
     return aps.stream().map(JvmBuckRuleComposer::getApPluginRulePath).collect(Collectors.toSet());
   }
 
   /**
    * Returns the java annotation processor plugin's rule name using the pluginUID
    *
-   * @param pluginUID pluginUID used to get the rule name
+   * @param plugin plugin used to get the rule name
    * @return Plugin rule name.
    */
-  protected static String getApPluginRuleName(String pluginUID) {
-    return String.format("processor_%s", pluginUID);
+  protected static String getApPluginRuleName(JvmPlugin plugin) {
+    return String.format("processor-%s", plugin.pluginUID());
   }
 
   /**
    * Returns the java annotation processor plugin's rule path using the pluginUID
    *
-   * @param pluginUID pluginUID used to get the rule path
+   * @param plugin plugin used to get the rule path
    * @return Plugin rule path.
    */
-  private static String getApPluginRulePath(String pluginUID) {
-    return String.format(
-        "//" + OkBuckGradlePlugin.WORKSPACE_PATH + "/processor:%s", getApPluginRuleName(pluginUID));
+  private static String getApPluginRulePath(JvmPlugin plugin) {
+    if (plugin.pluginDependency().isPresent()) {
+      return String.format(
+          "//%s:%s", plugin.pluginDependency().get().getTargetPath(), getApPluginRuleName(plugin));
+    } else {
+      return String.format(
+          "//" + OkBuckGradlePlugin.WORKSPACE_PATH + "/processor:%s", getApPluginRuleName(plugin));
+    }
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/annotation/JvmPlugin.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/annotation/JvmPlugin.java
@@ -1,0 +1,35 @@
+package com.uber.okbuck.core.annotation;
+
+import com.google.auto.value.AutoValue;
+import com.uber.okbuck.core.dependency.ExternalDependency;
+import com.uber.okbuck.core.model.base.Target;
+import java.util.Optional;
+
+@AutoValue
+public abstract class JvmPlugin {
+
+  public abstract String pluginUID();
+
+  public abstract Optional<ExternalDependency> pluginDependency();
+
+  public abstract Optional<Target> pluginTarget();
+
+  public static Builder builder() {
+    return new AutoValue_JvmPlugin.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setPluginUID(String value);
+
+    public abstract Builder setPluginDependency(Optional<ExternalDependency> value);
+
+    public abstract Builder setPluginDependency(ExternalDependency value);
+
+    public abstract Builder setPluginTarget(Optional<Target> value);
+
+    public abstract Builder setPluginTarget(Target value);
+
+    public abstract JvmPlugin build();
+  }
+}

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyCache.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyCache.java
@@ -115,7 +115,7 @@ public class DependencyCache {
    * @param externalDependency The dependency
    * @return Whether the dependency has auto value extension.
    */
-  public boolean hasAutoValueExtensions(ExternalDependency externalDependency) {
+  public boolean hasAutoValueExtension(ExternalDependency externalDependency) {
     ExternalDependency dependency =
         forcedDeps.getOrDefault(externalDependency.getVersionless(), externalDependency);
     try {

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/ExternalDependency.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/ExternalDependency.java
@@ -125,6 +125,11 @@ public class ExternalDependency {
     return this.base.targetName() + "." + getPackaging();
   }
 
+  /** Returns the target name of the dependency without packaging. */
+  public String getBaseTargetName() {
+    return this.base.targetName();
+  }
+
   /** Returns the versionless target name of the dependency. */
   public String getVersionlessTargetName() {
     return this.base.versionlessTargetName() + "." + getPackaging();

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/jvm/JvmTarget.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/jvm/JvmTarget.java
@@ -13,6 +13,7 @@ import com.google.errorprone.annotations.Var;
 import com.uber.okbuck.OkBuckGradlePlugin;
 import com.uber.okbuck.composer.jvm.JvmBuckRuleComposer;
 import com.uber.okbuck.core.annotation.AnnotationProcessorCache;
+import com.uber.okbuck.core.annotation.JvmPlugin;
 import com.uber.okbuck.core.dependency.DependencyFactory;
 import com.uber.okbuck.core.dependency.DependencyUtils;
 import com.uber.okbuck.core.dependency.ExternalDependency;
@@ -260,11 +261,11 @@ public class JvmTarget extends Target {
    * List of annotation processor classes. If annotation processor plugin is enabled returns the
    * annotation processor's UID.
    */
-  public Set<String> getApPlugins() {
+  public Set<JvmPlugin> getApPlugins() {
     return getAptScopes()
         .stream()
         .filter(scope -> !scope.getAnnotationProcessors().isEmpty())
-        .map(Scope::getAnnotationProcessorsUID)
+        .map(Scope::getAnnotationProcessorPlugin)
         .collect(Collectors.toSet());
   }
 
@@ -272,11 +273,11 @@ public class JvmTarget extends Target {
    * List of test annotation processor classes. If annotation processor plugin is enabled returns
    * the annotation processor's UID.
    */
-  public Set<String> getTestApPlugins() {
+  public Set<JvmPlugin> getTestApPlugins() {
     return getTestAptScopes()
         .stream()
         .filter(scope -> !scope.getAnnotationProcessors().isEmpty())
-        .map(Scope::getAnnotationProcessorsUID)
+        .map(Scope::getAnnotationProcessorPlugin)
         .collect(Collectors.toSet());
   }
 

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/ExternalDependenciesExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/ExternalDependenciesExtension.java
@@ -3,6 +3,7 @@ package com.uber.okbuck.extension;
 import com.google.common.collect.ImmutableSet;
 import com.uber.okbuck.core.dependency.VersionlessDependency;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -20,6 +21,8 @@ public class ExternalDependenciesExtension {
 
   /** Specifies whether to enable exported_deps for external dependencies or not. */
   @Input private boolean enableExportedDeps = false;
+
+  @Input private Set<String> autoValueConfigurations = new HashSet<>();
 
   /**
    * Stores the dependencies which are allowed to have more than 1 version. This is needed for few
@@ -89,5 +92,9 @@ public class ExternalDependenciesExtension {
 
   public boolean exportedDepsEnabled() {
     return enableExportedDeps;
+  }
+
+  public Set<String> getAutoValueConfigurations() {
+    return autoValueConfigurations;
   }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -48,6 +48,7 @@ def apt = [
         autoValue             : "com.google.auto.value:auto-value:1.6",
         autoValueAnnotations  : "com.google.auto.value:auto-value-annotations:1.6",
         autoValueGson         : "com.ryanharter.auto.value:auto-value-gson:0.7.0",
+        autoValueParcel       : "com.ryanharter.auto.value:auto-value-parcel:0.2.6",
         butterKnifeCompiler   : "com.jakewharton:butterknife-compiler:${versions.butterKnife}",
         daggerCompiler        : "com.google.dagger:dagger-compiler:${versions.dagger}",
         daggerAndroidProcessor: "com.google.dagger:dagger-android-processor:${versions.dagger}",


### PR DESCRIPTION
- Single processors work as expected.
- autoValue extensions need to pre predefined so that the dependency updater tool can work without having to infer auto value dependencies & its extensions by looking at the project's apt configuration. 
```file=build.gradle
okbuck {
    externalDependencies {
        autoValueConfigurations = [
            "autoValueAnnotations",
            "autoValueGson",
            "autoValueParcel",
        ]
    }
}

def autoValueDeps = [deps.apt.autoValue, deps.apt.autoValueAnnotations]
def autoValueGsonDeps = autoValueDeps + [deps.apt.autoValueGson]
def autoValueParcelDeps = autoValueDeps + [deps.apt.autoValueParcel]

afterEvaluate {
    dependencies {
        toolsExtraDepCache deps.external.saxon

        autoValueAnnotations autoValueDeps
        autoValueGson autoValueGsonDeps
        autoValueParcel autoValueParcelDeps
    }
}

``` 

- Auto value processors now take the configuration name instead of previous md5 suffixed names.
```
processor-auto-value-annotations
``` 
instead of 
```
processor_com.google.auto.value-auto-value-1.6__525046afa7fcbcf1dcd36f17908d83ff
```

