### PR TITLE
Small fix on android module macro

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidTestRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidTestRuleComposer.java
@@ -31,6 +31,8 @@ public final class AndroidTestRuleComposer extends AndroidBuckRuleComposer {
 
     List<String> testDeps = new ArrayList<>(deps);
     testDeps.add(":" + src(target));
+    testDeps.add(manifestRule);
+    testDeps.add(":" + res(target));
     testDeps.addAll(external(target.getExternalDeps(true)));
     testDeps.addAll(targets(target.getTargetDeps(true)));
 

--- a/buildSrc/src/main/java/com/uber/okbuck/generator/BuckFileGenerator.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/generator/BuckFileGenerator.java
@@ -171,6 +171,7 @@ public final class BuckFileGenerator {
         AndroidModuleRuleComposer.compose(
             target, deps, aidlRuleNames, appClass, extraResDeps));
 
+    // Adding resource and manig
     // Test
     if (target.getRobolectricEnabled()
         && !target.getTest().getSources().isEmpty()
@@ -254,9 +255,12 @@ public final class BuckFileGenerator {
     Rule testAppManifest = ManifestRuleComposer.composeForBinary(target);
     rules.add(testAppManifest);
 
+    List<String> srcAndResDeps = filterAndroidDepRules(rules);
+    srcAndResDeps.addAll(filterAndroidResDepRules(rules));
+
     rules.add(
         AndroidInstrumentationApkRuleComposer.compose(
-            filterAndroidDepRules(rules), mainApkTarget, testAppManifest.buckName()));
+            srcAndResDeps, mainApkTarget, testAppManifest.buckName()));
     rules.add(AndroidInstrumentationTestRuleComposer.compose(mainApkTarget));
     return rules;
   }

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/OkbuckAndroidModules.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/OkbuckAndroidModules.rocker.raw
@@ -93,7 +93,10 @@ def okbuck_android_module(
     )
     src_kwargs.update(kwargs)
 
-    src_deps = deps + res_lib_deps + [get_rule_dep(res_rule_name), get_rule_dep(manifest_rule_name)]
+    src_deps = deps + \
+               res_lib_deps + \
+               res_exported_lib_deps + \
+               [get_rule_dep(res_rule_name), get_rule_dep(manifest_rule_name)]
 
     src_kwargs.update({'deps' : sorted(src_deps)})
     if exported_deps:


### PR DESCRIPTION
Basically:
* res_release should go into the deps of the library and exported_deps of the corresponding resource (if respective src_release is in exported deps)
* res_release should go into the deps of the library and deps of the corresponding resource (if not respective src_release not exported)

This PR fixes the part of having the `res_release` as dep, in case it respective `src` was exported

EDIT

This PR also fixes missing `res` rules as dependencies for test rules (robolectric and instrumentation)