### PR TITLE
Partially revert #852

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidTestRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidTestRuleComposer.java
@@ -31,8 +31,6 @@ public final class AndroidTestRuleComposer extends AndroidBuckRuleComposer {
 
     List<String> testDeps = new ArrayList<>(deps);
     testDeps.add(":" + src(target));
-    testDeps.add(manifestRule);
-    testDeps.add(":" + res(target));
     testDeps.addAll(external(target.getExternalDeps(true)));
     testDeps.addAll(targets(target.getTargetDeps(true)));
 

--- a/buildSrc/src/main/java/com/uber/okbuck/generator/BuckFileGenerator.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/generator/BuckFileGenerator.java
@@ -171,7 +171,6 @@ public final class BuckFileGenerator {
         AndroidModuleRuleComposer.compose(
             target, deps, aidlRuleNames, appClass, extraResDeps));
 
-    // Adding resource and manig
     // Test
     if (target.getRobolectricEnabled()
         && !target.getTest().getSources().isEmpty()
@@ -255,12 +254,9 @@ public final class BuckFileGenerator {
     Rule testAppManifest = ManifestRuleComposer.composeForBinary(target);
     rules.add(testAppManifest);
 
-    List<String> srcAndResDeps = filterAndroidDepRules(rules);
-    srcAndResDeps.addAll(filterAndroidResDepRules(rules));
-
     rules.add(
         AndroidInstrumentationApkRuleComposer.compose(
-            srcAndResDeps, mainApkTarget, testAppManifest.buckName()));
+            filterAndroidDepRules(rules), mainApkTarget, testAppManifest.buckName()));
     rules.add(AndroidInstrumentationTestRuleComposer.compose(mainApkTarget));
     return rules;
   }


### PR DESCRIPTION
Reverts adding manifest and/or rules as deps on tests rules; This works, so it's better to leave this way as it's more intuitive to only depend on the actual library rule and not the hidden ones when writing BUCK files manually