### PR TITLE
Handle empty lint xml config properly for unified rule

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidModuleRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidModuleRuleComposer.java
@@ -97,9 +97,13 @@ public final class AndroidModuleRuleComposer extends AndroidBuckRuleComposer {
               .filter(t -> (t instanceof JvmTarget))
               .map(BuckRuleComposer::binTargets)
               .collect(Collectors.toSet());
+              
+      if (lintConfigPath != null) {
+        unifiedAndroid
+          .lintConfigXml(fileRule(lintConfigPath));
+      }
 
       unifiedAndroid
-          .lintConfigXml(fileRule(lintConfigPath))
           .customLints(customLintTargets)
           .lintOptions(target.getLintOptions());
     } else {


### PR DESCRIPTION
Similar to https://github.com/uber/okbuck/pull/849, but for kotlin