### PR TITLE
Fix typo when handling empty lint xml in pull/855

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidModuleRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/android/AndroidModuleRuleComposer.java
@@ -86,7 +86,7 @@ public final class AndroidModuleRuleComposer extends AndroidBuckRuleComposer {
                 target.getRootProject().getProjectDir(), target.getLintOptions().getLintConfig());
         ProjectUtil.getPlugin(target.getRootProject()).exportedPaths.add(lintConfigPath);
       } else {
-        lintConfigPath = "";
+        lintConfigPath = null;
       }
 
       Set<String> customLintTargets =


### PR DESCRIPTION
This adds a small change to https://github.com/uber/okbuck/pull/855