### PR TITLE
Ensure that test env dict is printed in sorted manner.

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/jvm/TestOptions.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/jvm/TestOptions.java
@@ -2,22 +2,23 @@ package com.uber.okbuck.core.model.jvm;
 
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 public final class TestOptions {
 
   private final List<String> jvmArgs;
-  private final Map<String, Object> env;
+  private final TreeMap<String, Object> env;
 
   public TestOptions(List<String> jvmArgs, Map<String, Object> env) {
     this.jvmArgs = jvmArgs;
-    this.env = env;
+    this.env = new TreeMap<>(env);
   }
 
   public List<String> getJvmArgs() {
     return jvmArgs;
   }
 
-  public Map<String, Object> getEnv() {
+  public TreeMap<String, Object> getEnv() {
     return env;
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/jvm/TestOptions.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/jvm/TestOptions.java
@@ -18,7 +18,7 @@ public final class TestOptions {
     return jvmArgs;
   }
 
-  public TreeMap<String, Object> getEnv() {
+  public Map<String, Object> getEnv() {
     return env;
   }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 // CI keeps gradle home cached based on the SHA of this file.
 // Update below to invalidate the cache.
-// Gradle Cache Version 2
+// Gradle Cache Version 3
 
 def versions = [
         androidPlugin      : "3.2.0",

--- a/libraries/javalibrary/build.gradle
+++ b/libraries/javalibrary/build.gradle
@@ -14,4 +14,8 @@ dependencies {
 
 test {
     environment "TEST_ENV", "true"
+    environment "CACHE_CASSANDRA_PORT", "1234"
+    environment "CACHE_CASSANDRA_CONTACT_POINTS", "[testhost]"
+    environment "OKBUCK_DATACENTER", "testdc1"
+    environment "OKBUCK_PORT_HTTP", "4321"
 }


### PR DESCRIPTION
Verified:

```
    env = {
        'CACHE_CASSANDRA_CONTACT_POINTS': '[testhost]',
        'CACHE_CASSANDRA_PORT': '1234',
        'OKBUCK_DATACENTER': 'testdc1',
        'OKBUCK_PORT_HTTP': '4321',
        'TEST_ENV': 'true',
    },
```