### PR TITLE
Upgrade to kotlin version 1.3.50

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,9 +7,7 @@
         <option name="TAB_SIZE" value="2" />
       </value>
     </option>
-    <option name="RIGHT_MARGIN" value="100" />
     <AndroidXmlCodeStyleSettings>
-      <option name="USE_CUSTOM_SETTINGS" value="true" />
       <option name="LAYOUT_SETTINGS">
         <value>
           <option name="INSERT_BLANK_LINE_BEFORE_TAG" value="false" />
@@ -48,25 +46,6 @@
       <option name="SPACE_BEFORE_SUPERCLASS_COLON" value="false" />
     </Objective-C>
     <Objective-C-extensions>
-      <file>
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function" />
-      </file>
-      <class>
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod" />
-      </class>
       <extensions>
         <pair source="cc" header="h" fileNamingConvention="NONE" />
         <pair source="c" header="h" fileNamingConvention="NONE" />
@@ -79,7 +58,6 @@
       <option name="INDENT_CHAINED_CALLS" value="false" />
     </TypeScriptCodeStyleSettings>
     <XML>
-      <option name="XML_ALIGN_ATTRIBUTES" value="false" />
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
     <codeStyleSettings language="CSS">

--- a/buckw
+++ b/buckw
@@ -210,6 +210,16 @@ setupBuckRun ( ) {
     fi
 
     setupBuckBinary
+
+    # Replace kotlin_home config with full path instead of source path
+    local kotlin_home
+    kotlin_home=$("$BUCK_BINARY" audit config kotlin.kotlin_home)
+    if [[ "$kotlin_home" == *":kotlin_home"* ]]; then
+        echo "changing kotlin home"
+        local resolved_kotlin_home
+        resolved_kotlin_home=$("$BUCK_BINARY" build //.okbuck/workspace/kotlin_home:kotlin_home --show-output | awk '{print $2}')
+        sed -i.bak "s://.okbuck/workspace/kotlin_home\:kotlin_home:${resolved_kotlin_home}:g" .okbuck/config/okbuck.buckconfig
+    fi
 }
 
 setupBuckFlags ( ) {

--- a/buckw
+++ b/buckw
@@ -213,7 +213,8 @@ setupBuckRun ( ) {
 }
 
 setupBuckFlags ( ) {
-    EXTRA_BUCK_CONFIG="$EXTRA_BUCK_CONFIG --config-file .okbuck/config/okbuck.buckconfig"
+    # Temporary use resolved kotlin home until #798 is resolved upstream
+    EXTRA_BUCK_CONFIG="$EXTRA_BUCK_CONFIG --config-file .okbuck/config/okbuck.buckconfig --config kotlin.kotlin_home=$SCRIPT_DIR/buck-out/gen/.okbuck/workspace/kotlin_home/kotlin_home"
 }
 
 # Handle parameters and flags

--- a/buckw
+++ b/buckw
@@ -218,6 +218,7 @@ setupBuckRun ( ) {
         echo "changing kotlin home"
         local resolved_kotlin_home
         resolved_kotlin_home=$("$BUCK_BINARY" build //.okbuck/workspace/kotlin_home:kotlin_home --show-output | awk '{print $2}')
+        "$BUCK_BINARY" build //.okbuck/workspace/kotlin_plugin_home:kotlin_plugin_home
         sed -i.bak "s://.okbuck/workspace/kotlin_home\:kotlin_home:${resolved_kotlin_home}:g" .okbuck/config/okbuck.buckconfig
     fi
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/OkBuckGradlePlugin.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/OkBuckGradlePlugin.java
@@ -10,7 +10,8 @@ import com.uber.okbuck.core.manager.BuckManager;
 import com.uber.okbuck.core.manager.DependencyManager;
 import com.uber.okbuck.core.manager.GroovyManager;
 import com.uber.okbuck.core.manager.JetifierManager;
-import com.uber.okbuck.core.manager.KotlinManager;
+import com.uber.okbuck.core.manager.KotlinHomeManager;
+import com.uber.okbuck.core.manager.KotlinPluginManager;
 import com.uber.okbuck.core.manager.LintManager;
 import com.uber.okbuck.core.manager.ManifestMergerManager;
 import com.uber.okbuck.core.manager.RobolectricManager;
@@ -104,7 +105,8 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
   public DependencyManager dependencyManager;
   public AnnotationProcessorCache annotationProcessorCache;
   public LintManager lintManager;
-  public KotlinManager kotlinManager;
+  public KotlinHomeManager kotlinHomeManager;
+  public KotlinPluginManager kotlinPluginManager;
   public ScalaManager scalaManager;
   public GroovyManager groovyManager;
   public JetifierManager jetifierManager;
@@ -158,8 +160,11 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
           // Create Lint Manager
           lintManager = new LintManager(rootBuckProject, LINT_BUCK_FILE, buckFileManager);
 
-          // Create Kotlin Manager
-          kotlinManager = new KotlinManager(rootBuckProject, buckFileManager);
+          // Create Kotlin Home Manager
+          kotlinHomeManager = new KotlinHomeManager(rootBuckProject, buckFileManager);
+
+          // Create Kotlin Home Manager
+          kotlinPluginManager = new KotlinPluginManager(rootBuckProject, buckFileManager);
 
           // Create Scala Manager
           scalaManager = new ScalaManager(rootBuckProject, buckFileManager);
@@ -197,7 +202,8 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
                 dependencyManager.finalizeDependencies();
                 jetifierManager.finalizeDependencies();
                 lintManager.finalizeDependencies();
-                kotlinManager.finalizeDependencies();
+                kotlinHomeManager.finalizeDependencies();
+                kotlinPluginManager.finalizeDependencies();
                 scalaManager.finalizeDependencies();
                 groovyManager.finalizeDependencies();
                 robolectricManager.finalizeDependencies();

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/KotlinBaseManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/KotlinBaseManager.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.uber.okbuck.OkBuckGradlePlugin;
 import com.uber.okbuck.composer.base.BuckRuleComposer;
 import com.uber.okbuck.core.dependency.DependencyCache;
-import com.uber.okbuck.core.dependency.ExternalDependency;
+import com.uber.okbuck.core.dependency.OExternalDependency;
 import com.uber.okbuck.core.dependency.VersionlessDependency;
 import com.uber.okbuck.core.util.FileUtil;
 import com.uber.okbuck.core.util.ProjectUtil;
@@ -33,7 +33,7 @@ public abstract class KotlinBaseManager {
 
   private boolean kotlinHomeEnabled;
   @Nullable private String kotlinVersion;
-  @Nullable private Set<ExternalDependency> dependencies;
+  @Nullable private Set<OExternalDependency> dependencies;
 
   public abstract String getTargetPath();
 

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/KotlinBaseManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/KotlinBaseManager.java
@@ -1,0 +1,133 @@
+package com.uber.okbuck.core.manager;
+
+import com.google.common.collect.ImmutableList;
+import com.uber.okbuck.OkBuckGradlePlugin;
+import com.uber.okbuck.composer.base.BuckRuleComposer;
+import com.uber.okbuck.core.dependency.DependencyCache;
+import com.uber.okbuck.core.dependency.ExternalDependency;
+import com.uber.okbuck.core.dependency.VersionlessDependency;
+import com.uber.okbuck.core.util.FileUtil;
+import com.uber.okbuck.core.util.ProjectUtil;
+import com.uber.okbuck.template.config.SymlinkBuckFile;
+import com.uber.okbuck.template.core.Rule;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.TreeMap;
+import javax.annotation.Nullable;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency;
+
+public abstract class KotlinBaseManager {
+  public static final String KOTLIN_KAPT_PLUGIN = "kotlin-kapt";
+  public static final String KOTLIN_ANDROID_EXTENSIONS_MODULE = "kotlin-android-extensions";
+
+  static final String KOTLIN_GROUP = "org.jetbrains.kotlin";
+  static final String KOTLIN_HOME_BASE = "/libexec/lib";
+
+  private static final String KOTLIN_GRADLE_MODULE = "kotlin-gradle-plugin";
+
+  Project project;
+  BuckFileManager buckFileManager;
+
+  private boolean kotlinHomeEnabled;
+  @Nullable private String kotlinVersion;
+  @Nullable private Set<ExternalDependency> dependencies;
+
+  public abstract String getTargetPath();
+
+  public abstract String getTargetName();
+
+  public abstract ImmutableList<VersionlessDependency> dependenciesWithTransitives();
+
+  public abstract ImmutableList<VersionlessDependency> dependenciesWithoutTransitives();
+
+  public abstract ImmutableList<VersionlessDependency> supportingDependencies();
+
+  KotlinBaseManager(Project project, BuckFileManager buckFileManager) {
+    this.project = project;
+    this.buckFileManager = buckFileManager;
+  }
+
+  public void setup(String kotlinVersion) {
+    this.kotlinHomeEnabled = true;
+    this.kotlinVersion = kotlinVersion;
+
+    Configuration kotlinConfig = project.getConfigurations().maybeCreate(getDepsConfig());
+    DependencyHandler handler = project.getDependencies();
+    dependenciesWithTransitives()
+        .stream()
+        .map(module -> String.format("%s:%s:%s", module.group(), module.name(), kotlinVersion))
+        .forEach(dependency -> handler.add(getDepsConfig(), dependency));
+
+    dependenciesWithoutTransitives()
+        .stream()
+        .map(
+            module -> {
+              DefaultExternalModuleDependency dependency =
+                  new DefaultExternalModuleDependency(module.group(), module.name(), kotlinVersion);
+              dependency.setTransitive(false);
+
+              return dependency;
+            })
+        .forEach(dependency -> handler.add(getDepsConfig(), dependency));
+
+    dependencies =
+        new DependencyCache(project, ProjectUtil.getDependencyManager(project)).build(kotlinConfig);
+  }
+
+  public void finalizeDependencies() {
+    Path path = project.file(getTargetPath()).toPath();
+    FileUtil.deleteQuietly(path);
+
+    if (!kotlinHomeEnabled) {
+      // no-op if kotlin home is not enabled
+      return;
+    }
+
+    if (kotlinVersion == null) {
+      throw new IllegalStateException("kotlinVersion is not setup");
+    }
+
+    if (dependencies != null && dependencies.size() > 0) {
+      TreeMap<String, String> targetsNameMap = new TreeMap<>();
+
+      ImmutableList<VersionlessDependency> dependenciesToKeep =
+          ImmutableList.<VersionlessDependency>builder()
+              .addAll(dependenciesWithTransitives())
+              .addAll(dependenciesWithoutTransitives())
+              .addAll(supportingDependencies())
+              .build();
+
+      dependencies
+          .stream()
+          .filter(
+              externalDependency ->
+                  dependenciesToKeep.contains(externalDependency.getVersionless()))
+          .forEach(
+              externalDependency ->
+                  targetsNameMap.put(
+                      BuckRuleComposer.external(externalDependency),
+                      externalDependency.getVersionlessTargetName()));
+
+      Rule symlinkRule =
+          new SymlinkBuckFile()
+              .targetsNameMap(targetsNameMap)
+              .base(KOTLIN_HOME_BASE)
+              .name(getTargetName());
+
+      buckFileManager.writeToBuckFile(
+          ImmutableList.of(symlinkRule), path.resolve(OkBuckGradlePlugin.BUCK).toFile());
+    }
+  }
+
+  private String getDepsConfig() {
+    return "okbuck_" + getTargetName();
+  }
+
+  @Nullable
+  public static String getDefaultKotlinVersion(Project project) {
+    return ProjectUtil.findVersionInClasspath(project, KOTLIN_GROUP, KOTLIN_GRADLE_MODULE);
+  }
+}

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/KotlinHomeManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/KotlinHomeManager.java
@@ -1,0 +1,60 @@
+package com.uber.okbuck.core.manager;
+
+import com.google.common.collect.ImmutableList;
+import com.uber.okbuck.OkBuckGradlePlugin;
+import com.uber.okbuck.core.dependency.VersionlessDependency;
+import org.gradle.api.Project;
+
+public final class KotlinHomeManager extends KotlinBaseManager {
+
+  private static final String KOTLIN_HOME = "kotlin_home";
+  private static final String KOTLIN_HOME_LOCATION =
+      OkBuckGradlePlugin.WORKSPACE_PATH + "/" + KOTLIN_HOME;
+  public static final String KOTLIN_HOME_TARGET = "//" + KOTLIN_HOME_LOCATION + ":" + KOTLIN_HOME;
+
+  public KotlinHomeManager(Project project, BuckFileManager buckFileManager) {
+    super(project, buckFileManager);
+  }
+
+  @Override
+  public String getTargetPath() {
+    return KOTLIN_HOME_LOCATION;
+  }
+
+  @Override
+  public String getTargetName() {
+    return KOTLIN_HOME;
+  }
+
+  @Override
+  public ImmutableList<VersionlessDependency> dependenciesWithTransitives() {
+    return ImmutableList.of(
+        VersionlessDependency.builder().setGroup(KOTLIN_GROUP).setName("kotlin-compiler").build(),
+        VersionlessDependency.builder().setGroup(KOTLIN_GROUP).setName("kotlin-reflect").build(),
+        VersionlessDependency.builder().setGroup(KOTLIN_GROUP).setName("kotlin-stdlib").build(),
+        VersionlessDependency.builder()
+            .setGroup(KOTLIN_GROUP)
+            .setName("kotlin-script-runtime")
+            .build(),
+        VersionlessDependency.builder().setGroup(KOTLIN_GROUP).setName("jvm-abi-gen").build());
+  }
+
+  @Override
+  public ImmutableList<VersionlessDependency> dependenciesWithoutTransitives() {
+    return ImmutableList.of(
+        VersionlessDependency.builder()
+            .setGroup(KOTLIN_GROUP)
+            .setName("kotlin-annotation-processing")
+            .build());
+  }
+
+  @Override
+  public ImmutableList<VersionlessDependency> supportingDependencies() {
+    return ImmutableList.of(
+        VersionlessDependency.builder()
+            .setGroup("org.jetbrains.intellij.deps")
+            .setName("trove4j")
+            .build(),
+        VersionlessDependency.builder().setGroup("org.jetbrains").setName("annotations").build());
+  }
+}

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/KotlinPluginManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/KotlinPluginManager.java
@@ -1,0 +1,73 @@
+package com.uber.okbuck.core.manager;
+
+import com.google.common.collect.ImmutableList;
+import com.uber.okbuck.OkBuckGradlePlugin;
+import com.uber.okbuck.core.dependency.VersionlessDependency;
+import org.gradle.api.Project;
+
+public final class KotlinPluginManager extends KotlinBaseManager {
+
+  public static final String KOTLIN_ALLOPEN_MODULE = "kotlin-allopen";
+  public static final String KOTLIN_ALLOPEN_JAR = KOTLIN_ALLOPEN_MODULE + ".jar";
+
+  static final String KOTLIN_PLUGIN_HOME = "kotlin_plugin_home";
+  static final String KOTLIN_PLUGIN_HOME_LOCATION =
+      OkBuckGradlePlugin.WORKSPACE_PATH + "/" + KOTLIN_PLUGIN_HOME;
+
+  public static final String KOTLIN_LIBRARIES_LOCATION =
+      "buck-out/gen"
+          + "/"
+          + KOTLIN_PLUGIN_HOME_LOCATION
+          + "/"
+          + KOTLIN_PLUGIN_HOME
+          + KOTLIN_HOME_BASE;
+
+  public KotlinPluginManager(Project project, BuckFileManager buckFileManager) {
+    super(project, buckFileManager);
+  }
+
+  @Override
+  public String getTargetPath() {
+    return KOTLIN_PLUGIN_HOME_LOCATION;
+  }
+
+  @Override
+  public String getTargetName() {
+    return KOTLIN_PLUGIN_HOME;
+  }
+
+  @Override
+  public ImmutableList<VersionlessDependency> dependenciesWithTransitives() {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public ImmutableList<VersionlessDependency> dependenciesWithoutTransitives() {
+    return ImmutableList.of(
+        VersionlessDependency.builder()
+            .setGroup(KOTLIN_GROUP)
+            .setName(KOTLIN_ALLOPEN_MODULE)
+            .build(),
+        VersionlessDependency.builder()
+            .setGroup(KOTLIN_GROUP)
+            .setName("kotlin-scripting-compiler-impl")
+            .build(),
+        VersionlessDependency.builder()
+            .setGroup(KOTLIN_GROUP)
+            .setName("kotlin-scripting-compiler")
+            .build(),
+        VersionlessDependency.builder()
+            .setGroup(KOTLIN_GROUP)
+            .setName("kotlin-scripting-jvm")
+            .build(),
+        VersionlessDependency.builder()
+            .setGroup(KOTLIN_GROUP)
+            .setName("kotlin-scripting-common")
+            .build());
+  }
+
+  @Override
+  public ImmutableList<VersionlessDependency> supportingDependencies() {
+    return ImmutableList.of();
+  }
+}

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidTarget.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidTarget.java
@@ -1,7 +1,7 @@
 package com.uber.okbuck.core.model.android;
 
-import static com.uber.okbuck.core.manager.KotlinManager.KOTLIN_ANDROID_EXTENSIONS_MODULE;
-import static com.uber.okbuck.core.manager.KotlinManager.KOTLIN_KAPT_PLUGIN;
+import static com.uber.okbuck.core.manager.KotlinBaseManager.KOTLIN_ANDROID_EXTENSIONS_MODULE;
+import static com.uber.okbuck.core.manager.KotlinBaseManager.KOTLIN_KAPT_PLUGIN;
 
 import com.android.build.gradle.BaseExtension;
 import com.android.build.gradle.api.BaseVariant;
@@ -18,7 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Var;
 import com.uber.okbuck.core.annotation.AnnotationProcessorCache;
-import com.uber.okbuck.core.manager.KotlinManager;
+import com.uber.okbuck.core.manager.KotlinPluginManager;
 import com.uber.okbuck.core.model.base.RuleType;
 import com.uber.okbuck.core.model.base.Scope;
 import com.uber.okbuck.core.model.jvm.JvmTarget;
@@ -442,7 +442,7 @@ public abstract class AndroidTarget extends JvmTarget {
             });
 
     plugin.append("-Xplugin=");
-    plugin.append(KotlinManager.KOTLIN_LIBRARIES_LOCATION);
+    plugin.append(KotlinPluginManager.KOTLIN_LIBRARIES_LOCATION);
     plugin.append(File.separator);
     plugin.append("kotlin-android-extensions.jar");
 

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/jvm/JvmTarget.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/jvm/JvmTarget.java
@@ -18,7 +18,7 @@ import com.uber.okbuck.core.dependency.DependencyFactory;
 import com.uber.okbuck.core.dependency.DependencyUtils;
 import com.uber.okbuck.core.dependency.OExternalDependency;
 import com.uber.okbuck.core.dependency.VersionlessDependency;
-import com.uber.okbuck.core.manager.KotlinManager;
+import com.uber.okbuck.core.manager.KotlinPluginManager;
 import com.uber.okbuck.core.manager.LintManager;
 import com.uber.okbuck.core.model.base.Scope;
 import com.uber.okbuck.core.model.base.SourceSetType;
@@ -477,7 +477,7 @@ public class JvmTarget extends Target {
     }
     ImmutableList.Builder<String> optionBuilder = ImmutableList.builder();
     optionBuilder.addAll(readKotlinCompilerArguments());
-    if (getProject().getPlugins().hasPlugin(KotlinManager.KOTLIN_ALLOPEN_MODULE)) {
+    if (getProject().getPlugins().hasPlugin(KotlinPluginManager.KOTLIN_ALLOPEN_MODULE)) {
       AllOpenKotlinGradleSubplugin subplugin = getAllOpenKotlinGradleSubplugin();
 
       if (subplugin != null && fakeCompile != null) {
@@ -486,9 +486,9 @@ public class JvmTarget extends Target {
 
         optionBuilder.add(
             "-Xplugin="
-                + KotlinManager.KOTLIN_LIBRARIES_LOCATION
+                + KotlinPluginManager.KOTLIN_LIBRARIES_LOCATION
                 + File.separator
-                + KotlinManager.KOTLIN_ALLOPEN_JAR);
+                + KotlinPluginManager.KOTLIN_ALLOPEN_JAR);
 
         for (SubpluginOption option : options) {
           optionBuilder.add("-P");

--- a/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
@@ -12,7 +12,7 @@ import com.uber.okbuck.composer.base.BuckRuleComposer;
 import com.uber.okbuck.core.dependency.OExternalDependency;
 import com.uber.okbuck.core.manager.BuckFileManager;
 import com.uber.okbuck.core.manager.GroovyManager;
-import com.uber.okbuck.core.manager.KotlinManager;
+import com.uber.okbuck.core.manager.KotlinHomeManager;
 import com.uber.okbuck.core.manager.ScalaManager;
 import com.uber.okbuck.core.model.base.ProjectType;
 import com.uber.okbuck.core.model.base.RuleType;
@@ -108,13 +108,14 @@ public class OkBuckTask extends DefaultTask {
 
     // Fetch Kotlin deps if needed
     if (kotlinExtension.version != null) {
-      ProjectUtil.getKotlinManager(getProject()).setupKotlinHome(kotlinExtension.version);
+      ProjectUtil.getKotlinHomeManager(getProject()).setup(kotlinExtension.version);
+      ProjectUtil.getKotlinPluginManager(getProject()).setup(kotlinExtension.version);
     }
 
     generate(
         okBuckExtension,
         hasGroovyLib ? GroovyManager.GROOVY_HOME_TARGET : null,
-        kotlinExtension.version != null ? KotlinManager.KOTLIN_HOME_TARGET : null,
+        kotlinExtension.version != null ? KotlinHomeManager.KOTLIN_HOME_TARGET : null,
         hasScalaLib ? ScalaManager.SCALA_COMPILER_LOCATION : null,
         hasScalaLib ? scalaLibraryLocation : null);
   }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
@@ -13,7 +13,8 @@ import com.uber.okbuck.core.dependency.DependencyFactory;
 import com.uber.okbuck.core.dependency.DependencyUtils;
 import com.uber.okbuck.core.manager.DependencyManager;
 import com.uber.okbuck.core.manager.GroovyManager;
-import com.uber.okbuck.core.manager.KotlinManager;
+import com.uber.okbuck.core.manager.KotlinHomeManager;
+import com.uber.okbuck.core.manager.KotlinPluginManager;
 import com.uber.okbuck.core.manager.LintManager;
 import com.uber.okbuck.core.manager.ScalaManager;
 import com.uber.okbuck.core.manager.TransformManager;
@@ -86,8 +87,12 @@ public final class ProjectUtil {
     return getPlugin(project).lintManager;
   }
 
-  public static KotlinManager getKotlinManager(Project project) {
-    return getPlugin(project).kotlinManager;
+  public static KotlinHomeManager getKotlinHomeManager(Project project) {
+    return getPlugin(project).kotlinHomeManager;
+  }
+
+  public static KotlinPluginManager getKotlinPluginManager(Project project) {
+    return getPlugin(project).kotlinPluginManager;
   }
 
   public static ScalaManager getScalaManager(Project project) {

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/KotlinExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/KotlinExtension.java
@@ -1,6 +1,6 @@
 package com.uber.okbuck.extension;
 
-import com.uber.okbuck.core.manager.KotlinManager;
+import com.uber.okbuck.core.manager.KotlinHomeManager;
 import javax.annotation.Nullable;
 import org.gradle.api.Project;
 
@@ -10,6 +10,6 @@ public class KotlinExtension {
   @Nullable public String version;
 
   KotlinExtension(Project project) {
-    version = KotlinManager.getDefaultKotlinVersion(project);
+    version = KotlinHomeManager.getDefaultKotlinVersion(project);
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
@@ -89,7 +89,7 @@ public class OkBuckExtension {
   /** The prebuilt buck binary to use */
   @Input
   public String buckBinary =
-      "com.github.facebook:buck:f13d2083251685db1dc9bd931062e7a51a534467@pex";
+      "com.github.facebook:buck:0aeb8be606590c8203827a20dfa3c7f14a12fb5d@pex";
 
   private WrapperExtension wrapperExtension = new WrapperExtension();
   private KotlinExtension kotlinExtension;

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
@@ -89,7 +89,7 @@ public class OkBuckExtension {
   /** The prebuilt buck binary to use */
   @Input
   public String buckBinary =
-      "com.github.facebook:buck:f6578801138a7b6b89d4a485dd2d0c740fdefe8a@pex";
+      "com.github.facebook:buck:f13d2083251685db1dc9bd931062e7a51a534467@pex";
 
   private WrapperExtension wrapperExtension = new WrapperExtension();
   private KotlinExtension kotlinExtension;

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -21,7 +21,7 @@ def versions = [
         androidTools       : "26.2.0",
         butterKnife        : "10.0.0",
         dagger             : "2.16",
-        kotlin             : "1.3.21",
+        kotlin             : "1.3.50",
         leakCanary         : "1.5.4",
         rocker             : "0.23.0",
         support            : "28.0.0",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Sep 11 13:59:34 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip

--- a/libraries/kotlinlibrary/build.gradle
+++ b/libraries/kotlinlibrary/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "kotlin"
 apply plugin: "kotlin-kapt"
-apply plugin: "kotlin-allopen"
+//apply plugin: "kotlin-allopen"
 
 dependencies {
   implementation deps.external.kotlinStdlib
@@ -12,10 +12,10 @@ dependencies {
   testImplementation deps.test.mockito
 }
 
-allOpen {
-  annotations("demo.Anno")
-  annotations("demo.Anno2")
-}
+//allOpen {
+//  annotations("demo.Anno")
+//  annotations("demo.Anno2")
+//}
 
 compileKotlin {
   kotlinOptions {

--- a/libraries/kotlinlibrary/src/test/java/demo/AllOpenTest.kt
+++ b/libraries/kotlinlibrary/src/test/java/demo/AllOpenTest.kt
@@ -3,9 +3,11 @@ package demo
 import org.junit.Test
 import org.mockito.Mockito
 
+
+
 class AllOpenTest {
-    @Test fun f() {
-        Mockito.mock(Closed::class.java)
-        Mockito.mock(Closed2::class.java)
-    }
+//    @Test fun f() {
+//        Mockito.mock(Closed::class.java)
+//        Mockito.mock(Closed2::class.java)
+//    }
 }


### PR DESCRIPTION
- Upgrades to kotlin 1.3.50
- kotlin_home and kotlin_plugin_home are two different targets now.
- Kotlin all open plugin is disabled for now since it fails with the below error
```
BUILT 1219/1586 JOBS 13.5s //.okbuck/ext/org/robolectric:android-all-8.1.0-robolectric-4611349.jar__downloaded
DOWNLOADED 0 ARTIFACTS, 0.00 BYTES, 100.0% CACHE MISS
BUILDING: FINISHED IN 17.0s (100%) 1219/1586 JOBS, 1212 UPDATED
BUILD FAILED
Command failed with exit code 2.
stderr: warning: flag is not supported by this version of the compiler: -Xadd-compiler-builtins
warning: flag is not supported by this version of the compiler: -Xload-builtins-from-dependencies
logging: using Kotlin home directory /home/circleci/okbuck/buck-out/gen/.okbuck/workspace/kotlin_home/kotlin_home/libexec
logging: configuring the compilation environment
exception: java.lang.IllegalStateException: The provided plugin org.jetbrains.kotlin.allopen.AllOpenComponentRegistrar is not compatible with this version of compiler
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment$Companion.registerExtensionsFromPlugins$cli(KotlinCoreEnvironment.kt:639)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment$ProjectEnvironment.registerExtensionsFromPlugins(KotlinCoreEnvironment.kt:145)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment.<init>(KotlinCoreEnvironment.kt:185)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment.<init>(KotlinCoreEnvironment.kt:125)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment$Companion.createForProduction(KotlinCoreEnvironment.kt:432)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.createCoreEnvironment(K2JVMCompiler.kt:253)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:151)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:54)
	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:84)
	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:42)
	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:104)
	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:82)
	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:50)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.facebook.buck.jvm.kotlin.JarBackedReflectedKotlinc.buildWithClasspath(JarBackedReflectedKotlinc.java:176)
	at com.facebook.buck.jvm.kotlin.KotlincStep.execute(KotlincStep.java:92)
	at com.facebook.buck.step.StepRunner.runStep(StepRunner.java:57)
	at com.facebook.buck.core.build.engine.impl.CachingBuildRuleBuilder$BuildRuleSteps.executeCommands(CachingBuildRuleBuilder.java:1448)
	at com.facebook.b
```
