### PR TITLE
Stricter check for changing dependencies

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/DependencyManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/DependencyManager.java
@@ -45,12 +45,8 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.artifacts.ResolvedDependency;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DependencyManager {
-
-  private static final Logger LOG = LoggerFactory.getLogger(DependencyManager.class);
 
   private final Project project;
   private final ExternalDependenciesExtension externalDependenciesExtension;
@@ -195,30 +191,6 @@ public class DependencyManager {
         throw new RuntimeException(
             "Single version found for external dependencies, please remove them from external dependency extension: \n"
                 + mapJoiner.join(singleDependencies));
-      }
-    }
-
-    String changingDeps =
-        dependencyMap
-            .values()
-            .stream()
-            .flatMap(Collection::stream)
-            .filter(
-                dependency -> {
-                  String version = dependency.getVersion();
-                  return version.endsWith("+") || version.contains("[") || version.endsWith("-SNAPSHOT");
-                })
-            .map(ExternalDependency::getTargetName)
-            .collect(Collectors.joining("\n"));
-
-    if (!changingDeps.isEmpty()) {
-      String message =
-          "Please do not use changing dependencies. They can cause hard to reproduce builds.\n"
-              + changingDeps;
-      if (ProjectUtil.getOkBuckExtension(project).failOnChangingDependencies) {
-        throw new IllegalStateException(message);
-      } else {
-        LOG.warn(message);
       }
     }
   }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/DependencyManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/DependencyManager.java
@@ -206,7 +206,7 @@ public class DependencyManager {
             .filter(
                 dependency -> {
                   String version = dependency.getVersion();
-                  return version.endsWith("+") || version.endsWith("-SNAPSHOT");
+                  return version.endsWith("+") || version.contains("[") || version.endsWith("-SNAPSHOT");
                 })
             .map(ExternalDependency::getTargetName)
             .collect(Collectors.joining("\n"));

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/base/Scope.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/base/Scope.java
@@ -94,7 +94,7 @@ public class Scope {
     this.configuration = configuration;
 
     if (configuration != null) {
-      enforceChangingDeps(project, configuration);
+      DependencyUtils.enforceChangingDeps(project, configuration);
       extractConfiguration(configuration);
     }
   }
@@ -297,35 +297,6 @@ public class Scope {
                     .collect(Collectors.toSet())));
 
     return artifactResultsBuilder.build();
-  }
-
-  private static void enforceChangingDeps(Project project, Configuration configuration) {
-    Map<String, String> dynamicDependencyVersionMap =
-        ProjectUtil.getOkBuckExtension(project).getExternalDependenciesExtension()
-            .getDynamicDependencyVersionMap();
-    configuration.resolutionStrategy(
-        strategy -> {
-          strategy.eachDependency(
-              details -> {
-                String requested = details.getRequested().getVersion();
-                if (requested != null) {
-                  if (requested.startsWith("+") || requested.contains(",")) {
-                    String useVersion =
-                        dynamicDependencyVersionMap.get(details.getRequested().toString());
-                    if (useVersion != null) {
-                      details.useVersion(useVersion);
-                    } else {
-                      throw new RuntimeException(
-                          "Please do not use changing dependencies. They can cause hard to reproduce builds.\n"
-                              + "Found changing dependency "
-                              + details.getRequested()
-                              + " in Project: "
-                              + project);
-                    }
-                  }
-                }
-              });
-        });
   }
 
   private void extractConfiguration(Configuration configuration) {

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/ExternalDependenciesExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/ExternalDependenciesExtension.java
@@ -3,8 +3,10 @@ package com.uber.okbuck.extension;
 import com.google.common.collect.ImmutableSet;
 import com.uber.okbuck.core.dependency.VersionlessDependency;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.gradle.api.tasks.Input;
@@ -30,6 +32,12 @@ public class ExternalDependenciesExtension {
    */
   @Input
   private List<String> allowAllVersions = Collections.singletonList("org.robolectric:android-all");
+
+  /**
+   * Stores the dependency versions to be used for dynamic notations that have , or + in their
+   * versions
+   */
+  @Input private Map<String, String> dynamicDependencyVersionMap = new HashMap<>();
 
   @Nullable private Set<VersionlessDependency> allowAllVersionsSet;
 
@@ -96,5 +104,9 @@ public class ExternalDependenciesExtension {
 
   public Set<String> getAutoValueConfigurations() {
     return autoValueConfigurations;
+  }
+
+  public Map<String, String> getDynamicDependencyVersionMap() {
+    return dynamicDependencyVersionMap;
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/ExternalDependenciesExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/ExternalDependenciesExtension.java
@@ -39,6 +39,12 @@ public class ExternalDependenciesExtension {
    */
   @Input private Map<String, String> dynamicDependencyVersionMap = new HashMap<>();
 
+  /**
+   * Stores the dynamic dependencies to ignore if they are resolved with other gradle resolution
+   * mechanisms
+   */
+  @Input private Set<String> dynamicDependenciesToIgnore = new HashSet<>();
+
   @Nullable private Set<VersionlessDependency> allowAllVersionsSet;
 
   public ExternalDependenciesExtension() {}
@@ -108,5 +114,9 @@ public class ExternalDependenciesExtension {
 
   public Map<String, String> getDynamicDependencyVersionMap() {
     return dynamicDependencyVersionMap;
+  }
+
+  public Set<String> getDynamicDependenciesToIgnore() {
+    return dynamicDependenciesToIgnore;
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to okbuck. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
Changing dependencies like `[2.2,)` are not visible after configuration resolution but can still cause non hermetic builds. See [gradle docs](https://docs.gradle.org/current/userguide/declaring_dependencies.html)

This change adds a new extension to pick a fixed version when encountering any such dependencies before resolution and during validation. It also adds the ability to ignore changing dependencies if they are resolved with other gradle resolution mechanisms

Example configuration:
```
okbuck {
    dynamicDependencyVersionMap = [
        "com.google.guava:guava:19+" : "24.1.1-jre",
        "com.google.guava:guava:[10.+,)" : "24.1.1-jre",
        "com.google.guava:guava:[14.0, 18.0]" : "18.0",
        "ml.dmlc:xgboost4j-spark:0.7-SNAPSHOT" : "0.7",
    ]
    dynamicDependenciesToIgnore = [
        "ml.combust.mleap:mleap-xgboost-spark_2.11:0.10.0-SNAPSHOT",
    ]
}
```

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:
