### PR TITLE
[okbuck] Reverse assumption on standard naming of android_modules

### DIFF
--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/OkbuckAndroidModules.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/OkbuckAndroidModules.rocker.raw
@@ -16,7 +16,7 @@ def src_to_res(str):
 def get_libs_res_deps(src_deps):
     mapped_res_deps = []
     for dep in src_deps:
-        if (':src_' in dep and not dep.endswith(':src_main')):
+        if (dep.endswith(':src_release')):
             mapped_res_deps.append(src_to_res(dep))
     return mapped_res_deps
 


### PR DESCRIPTION
<!--
Thank you for contributing to okbuck. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
Reverse the assumption on naming conventions of android modules for auto-including 
android_resource rules. After this change only rules defined as src_release will have the
res_release automatically included as deps.

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:
