### PR TITLE
Script to create tinyjavaxtools.jar, for supporting Error Prone in Buck builds

### DIFF
--- a/tooling/errorprone/createtinyjavaxtools.sh
+++ b/tooling/errorprone/createtinyjavaxtools.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -ex
+
+DIR=$(pwd)
+
+# works on Linux and Mac; see https://unix.stackexchange.com/questions/30091/fix-or-alternative-for-mktemp-in-os-x
+WORK_DIR=`mktemp -d 2>/dev/null || mktemp -d -t 'tmpdir'`
+
+if [[ ! "$WORK_DIR" || ! -d "$WORK_DIR" ]]; then
+  echo "Could not create temp dir"
+  exit 1
+fi
+
+function cleanup {      
+  rm -rf "$WORK_DIR"
+}
+
+trap cleanup EXIT
+
+get_abs_filename() {
+  # $1 : relative filename
+  echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+}
+
+JARABSPATH=$(get_abs_filename $1)
+
+(cd $WORK_DIR && jar xf $JARABSPATH && jar cf tinyjavaxtools.jar 'javax/tools/StandardJavaFileManager$PathFactory.class' 'javax/tools/JavaFileManager.class' 'javax/tools/StandardJavaFileManager.class' 'javax/tools/FileManagerUtils.class' 'javax/tools/StandardLocation$1.class' 'javax/tools/FileManagerUtils$1.class' 'javax/tools/StandardLocation$2.class' 'javax/tools/JavaFileManager$Location.class' 'javax/tools/StandardLocation.class' 'javax/tools/FileManagerUtils$2.class' 'javax/lang/model/type/TypeKind$1.class' 'javax/lang/model/type/TypeKind.class' && cp tinyjavaxtools.jar $DIR)
+
+


### PR DESCRIPTION
This script goes along with these instructions for enabling Error Prone in Buck builds with OkBuck:

https://github.com/msridhar/okbuck/wiki/Using-Error-Prone-with-Buck-and-OkBuck

The script creates the `tinyjavaxtools.jar` file necessary to make Error Prone work with Buck.  The instructions above should be copied to the OkBuck wiki alongside merging this PR.

I'd like feedback on both the script and the instructions.  In particular, regarding the instructions:
* How can I tweak them to also work for Android builds (I don't think `compileJava` exists there)?
* Is there an easy-ish way to make the instructions compatible with using the Gradle Error Prone  plugin?  Or, absent that, is there at least a way to make them not break the Gradle build?  Like can we set things up so the `compileJava` arguments are only added when an OkBuck task is running?