### PR TITLE
Use weak references for dep cache

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyFactory.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyFactory.java
@@ -4,12 +4,13 @@ import com.google.common.base.Strings;
 import com.uber.okbuck.extension.ExternalDependenciesExtension;
 import com.uber.okbuck.extension.JetifierExtension;
 import java.io.File;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.WeakHashMap;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FilenameUtils;
 import org.gradle.api.artifacts.ExternalDependency;
@@ -22,12 +23,11 @@ public final class DependencyFactory {
 
   private static final String LOCAL_DEP_VERSION = "1.0.0-LOCAL";
 
-  // Use instance of Dependency Factory and clean it up b/w runs
-  private static HashMap<ExternalDependency, Set<VersionlessDependency>> unresolvedToVersionless =
-      new HashMap<>();
+  private static Map<ExternalDependency, Set<VersionlessDependency>> unresolvedToVersionless =
+      new WeakHashMap<>();
 
-  private static HashMap<OResolvedDependency, OExternalDependency> externalDependencyCache =
-      new HashMap<>();
+  private static Map<OResolvedDependency, OExternalDependency> externalDependencyCache =
+      new WeakHashMap<>();
 
   private DependencyFactory() {}
 
@@ -129,7 +129,8 @@ public final class DependencyFactory {
         vDependencyBuilder.setGroup(group);
       }
 
-      Set<VersionlessDependency> vDeps = new HashSet<>();
+      Set<VersionlessDependency> vDeps = Collections.newSetFromMap(
+        new WeakHashMap<VersionlessDependency, Boolean>());
 
       if (dependency.getArtifacts().size() > 0) {
         vDeps.addAll(
@@ -196,7 +197,7 @@ public final class DependencyFactory {
   }
 
   public static void cleanup() {
-    unresolvedToVersionless = new HashMap<>();
-    externalDependencyCache = new HashMap<>();
+    unresolvedToVersionless.clear();
+    externalDependencyCache.clear();
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to okbuck. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:

If okbuck is killed using sigint midway during okbuck, the depcache is not cleaned up properly by GC since they hold strong references and a new invocation of okbuck will create new instances of dependency objects which just keep getting added to the existing ones and can hang the build due to gc pauses if the heap is not big enough.

This changes both the maps/sets to dependency objects to be weak ones so they can be garbage collected even if okbuck is killed midway

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:
