### PR TITLE
Use dependency factory instance instead of the static class

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/OkBuckGradlePlugin.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/OkBuckGradlePlugin.java
@@ -100,6 +100,7 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
   public final Set<String> exportedPaths = Sets.newConcurrentHashSet();
 
   public DependencyCache depCache;
+  public DependencyFactory dependencyFactory;
   public DependencyManager dependencyManager;
   public AnnotationProcessorCache annotationProcessorCache;
   public LintManager lintManager;
@@ -144,6 +145,8 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
           // Create buck file manager.
           BuckFileManager buckFileManager =
               new BuckFileManager(okbuckExt.getRuleOverridesExtension());
+
+          dependencyFactory = new DependencyFactory();
 
           // Create Annotation Processor cache
           annotationProcessorCache =
@@ -200,6 +203,8 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
                 transformManager.finalizeDependencies();
                 buckManager.finalizeDependencies();
                 manifestMergerManager.finalizeDependencies();
+                dependencyFactory.finalizeDependencies();
+
                 writeExportedFileRules(rootBuckProject, okbuckExt);
 
                 // Reset root project's scope cache at the very end
@@ -210,9 +215,6 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
                 // the target cache is accessed by other projects and have to
                 // be available until okbuck tasks of all the projects finishes.
                 ProjectCache.resetTargetCacheForAll(rootProject);
-
-                // Cleanup static maps in dependency factory.
-                DependencyFactory.cleanup();
               });
 
           WrapperExtension wrapper = okbuckExt.getWrapperExtension();

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyUtils.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyUtils.java
@@ -158,20 +158,22 @@ public final class DependencyUtils {
                     && ((ModuleComponentIdentifier) identifier).getVersion().length() > 0) {
                   ModuleComponentIdentifier moduleIdentifier =
                       (ModuleComponentIdentifier) identifier;
-                  return DependencyFactory.from(
-                      moduleIdentifier.getGroup(),
-                      moduleIdentifier.getModule(),
-                      moduleIdentifier.getVersion(),
-                      artifact.getFile(),
-                      sourcesArtifact != null ? sourcesArtifact.getFile() : null,
-                      externalDependenciesExtension,
-                      jetifierExtension);
+                  return ProjectUtil.getDependencyFactory(project)
+                      .from(
+                          moduleIdentifier.getGroup(),
+                          moduleIdentifier.getModule(),
+                          moduleIdentifier.getVersion(),
+                          artifact.getFile(),
+                          sourcesArtifact != null ? sourcesArtifact.getFile() : null,
+                          externalDependenciesExtension,
+                          jetifierExtension);
                 } else {
-                  return DependencyFactory.fromLocal(
-                      artifact.getFile(),
-                      sourcesArtifact != null ? sourcesArtifact.getFile() : null,
-                      externalDependenciesExtension,
-                      jetifierExtension);
+                  return ProjectUtil.getDependencyFactory(project)
+                      .fromLocal(
+                          artifact.getFile(),
+                          sourcesArtifact != null ? sourcesArtifact.getFile() : null,
+                          externalDependenciesExtension,
+                          jetifierExtension);
                 }
               })
           .collect(Collectors.toSet());

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/base/Scope.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/base/Scope.java
@@ -277,6 +277,8 @@ public class Scope {
   }
 
   private void extractConfiguration(Configuration configuration) {
+    DependencyFactory factory = ProjectUtil.getDependencyFactory(project);
+
     ExternalDependenciesExtension externalDependenciesExtension =
         ProjectUtil.getExternalDependencyExtension(project);
 
@@ -299,7 +301,7 @@ public class Scope {
             .getAllDependencies()
             .withType(ExternalDependency.class)
             .stream()
-            .map(DependencyFactory::fromDependency)
+            .map(factory::fromDependency)
             .flatMap(Collection::stream)
             .collect(Collectors.toSet());
 
@@ -402,7 +404,7 @@ public class Scope {
           .map(dependency -> (ExternalDependency) dependency)
           .forEach(
               dependency -> {
-                Set<VersionlessDependency> vDeps = DependencyFactory.fromDependency(dependency);
+                Set<VersionlessDependency> vDeps = factory.fromDependency(dependency);
                 vDeps.forEach(
                     vDep -> {
                       OExternalDependency eDep = allExternal.getOrDefault(vDep, null);
@@ -421,6 +423,8 @@ public class Scope {
       Configuration configuration,
       Set<String> projectFirstLevel,
       Set<VersionlessDependency> externalFirstLevel) {
+    DependencyFactory factory = ProjectUtil.getDependencyFactory(project);
+
     Set<ResolvedArtifactResult> jarArtifacts =
         getArtifacts(configuration, PROJECT_FILTER, ImmutableList.of("jar"));
 
@@ -475,7 +479,7 @@ public class Scope {
 
             @Var
             OExternalDependency externalDependency =
-                DependencyFactory.from(
+                factory.from(
                     moduleIdentifier.getGroup(),
                     moduleIdentifier.getModule(),
                     moduleIdentifier.getVersion(),
@@ -508,7 +512,7 @@ public class Scope {
               }
               @Var
               OExternalDependency localExternalDependency =
-                  DependencyFactory.fromLocal(
+                  factory.fromLocal(
                       artifact.getFile(),
                       sourcesArtifact != null ? sourcesArtifact.getFile() : null,
                       externalDependenciesExtension,

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/jvm/JvmTarget.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/jvm/JvmTarget.java
@@ -212,12 +212,13 @@ public class JvmTarget extends Target {
     Configuration apiConfiguration = getApiConfiguration();
 
     if (apiConfiguration != null) {
+      DependencyFactory factory = ProjectUtil.getDependencyFactory(getProject());
       Set<VersionlessDependency> versionlessApiDependencies =
           apiConfiguration
               .getAllDependencies()
               .withType(org.gradle.api.artifacts.ExternalDependency.class)
               .stream()
-              .map(DependencyFactory::fromDependency)
+              .map(factory::fromDependency)
               .flatMap(Collection::stream)
               .collect(Collectors.toSet());
 

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableList;
 import com.uber.okbuck.OkBuckGradlePlugin;
 import com.uber.okbuck.core.annotation.AnnotationProcessorCache;
 import com.uber.okbuck.core.dependency.DependencyCache;
+import com.uber.okbuck.core.dependency.DependencyFactory;
 import com.uber.okbuck.core.dependency.DependencyUtils;
 import com.uber.okbuck.core.manager.DependencyManager;
 import com.uber.okbuck.core.manager.GroovyManager;
@@ -71,6 +72,10 @@ public final class ProjectUtil {
 
   public static AnnotationProcessorCache getAnnotationProcessorCache(Project project) {
     return getPlugin(project).annotationProcessorCache;
+  }
+
+  public static DependencyFactory getDependencyFactory(Project project) {
+    return getPlugin(project).dependencyFactory;
   }
 
   public static DependencyManager getDependencyManager(Project project) {


### PR DESCRIPTION
Using an instance of dependency factory which won't require to keep weak map.

Versionless dependency objects are being garbage collected from `unresolvedToVersionless` during okbuck run since no one keeps a strong reference to them. This makes the values disappear while the key still remains on the map. Although making vDeps just a normal set would work, but instead moving to using an instance.