### PR TITLE
Use getParentArtifacts api to populate child deps

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyUtils.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyUtils.java
@@ -285,8 +285,4 @@ public final class DependencyUtils {
         .map(artifact -> artifact.getId().getComponentIdentifier())
         .anyMatch(artifactId -> !(artifactId instanceof ProjectComponentIdentifier));
   }
-
-  public static String versionlessGroupingKey(ResolvedDependency dependency) {
-    return dependency.getModuleGroup() + ":" + dependency.getModuleName();
-  }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/DependencyManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/DependencyManager.java
@@ -310,6 +310,8 @@ public class DependencyManager {
         .stream()
         .map(
             cDependency ->
+                // TODO:Replace with using childFromDependency instead
+                // which ensures that the right child deps are only fetched.
                 DependencyFactory.fromDependency(cDependency)
                     .stream()
                     .peek(


### PR DESCRIPTION
Child artifacts from a resolved child dependency is added based on the `getParentArtifacts` api.
This ensures that not all child artifacts gets added to the parent but only the defined ones. 