### PR TITLE
Update to latest buck version and use kotlin compiler zip

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,11 +1,9 @@
 [project]
-    glob_handler = watchman
     allow_symlinks = forbid
     ide = intellij
     ignore = .git, .idea, .gradle, local.properties, **/.DS_Store, **/*.iml
     temp_files = ^#.*#$, .*~$, .*.swp$
     parallel_parsing = true
-    build_file_search_method = watchman
     skip_build = true
 
 [httpserver]

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ env:
     - BUILD_CMD=test
 
 install:
-  - set -exo pipefail
   - mkdir python_tmp
   - wget https://github.com/kageiit/jitpack-python/releases/download/3.8/python-3.8-ubuntu-16.tar.gz -O python_tmp/python.tar.gz
   - tar -C python_tmp -xf python_tmp/python.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - mkdir python_tmp
   - wget https://github.com/kageiit/jitpack-python/releases/download/3.8/python-3.8-ubuntu-16.tar.gz -O python_tmp/python.tar.gz
   - tar -C python_tmp -xf python_tmp/python.tar.gz
-  - export PATH="$PATH:python_tmp/bin"
+  - export PATH="python_tmp/bin:$PATH"
   - python3 --version
   - python2 --version
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ install:
   - wget https://github.com/kageiit/jitpack-python/releases/download/3.8/python-3.8-ubuntu-16.tar.gz -O python_tmp/python.tar.gz
   - tar -C python_tmp -xf python_tmp/python.tar.gz
   - export PATH="$PATH:python_tmp/bin"
+  - python3 --version
+  - python2 --version
+  - python --version
   - mkdir -p $HOME/android-sdk-dl
   - mkdir -p $HOME/android-sdk
   - curl https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip > $HOME/android-sdk-dl/sdk-tools.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,11 @@ env:
     - BUILD_CMD=test
 
 install:
+  - set -exo pipefail
+  - mkdir python_tmp
+  - wget https://github.com/kageiit/jitpack-python/releases/download/3.8/python-3.8-ubuntu-16.tar.gz -O python_tmp/python.tar.gz
+  - tar -C python_tmp -xf python_tmp/python.tar.gz
+  - export PATH="$PATH:python_tmp/bin"
   - mkdir -p $HOME/android-sdk-dl
   - mkdir -p $HOME/android-sdk
   - curl https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip > $HOME/android-sdk-dl/sdk-tools.zip

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     implementation deps.build.kotlinPlugin
     implementation deps.build.mavenArtifact
     implementation deps.build.rockerRuntime
-    implementation deps.build.guava
+    implementation deps.external.guava
     implementation deps.external.gson
     implementation deps.lint.lintGradle
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -57,8 +57,8 @@ dependencies {
     implementation deps.build.kotlinPlugin
     implementation deps.build.mavenArtifact
     implementation deps.build.rockerRuntime
+    implementation deps.build.guava
     implementation deps.external.gson
-    implementation deps.external.guava
     implementation deps.lint.lintGradle
 
     testImplementation deps.test.junit

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/KotlinManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/KotlinManager.java
@@ -1,90 +1,52 @@
 package com.uber.okbuck.core.manager;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.uber.okbuck.OkBuckGradlePlugin;
-import com.uber.okbuck.composer.base.BuckRuleComposer;
-import com.uber.okbuck.core.dependency.DependencyCache;
-import com.uber.okbuck.core.dependency.OExternalDependency;
 import com.uber.okbuck.core.model.base.RuleType;
 import com.uber.okbuck.core.util.FileUtil;
-import com.uber.okbuck.core.util.ProjectUtil;
-import com.uber.okbuck.template.config.SymlinkBuckFile;
+import com.uber.okbuck.extension.KotlinExtension;
+import com.uber.okbuck.template.common.Genrule;
+import com.uber.okbuck.template.common.HttpArchive;
 import com.uber.okbuck.template.core.Rule;
-import com.uber.okbuck.template.jvm.JvmBinaryRule;
+import com.uber.okbuck.template.java.NativePrebuilt;
 import java.nio.file.Path;
-import java.util.Set;
-import java.util.TreeMap;
 import javax.annotation.Nullable;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.dsl.DependencyHandler;
 
 public final class KotlinManager {
   public static final String KOTLIN_ANDROID_EXTENSIONS_MODULE = "kotlin-android-extensions";
   public static final String KOTLIN_ALLOPEN_MODULE = "kotlin-allopen";
-  public static final String KOTLIN_ALLOPEN_JAR = KOTLIN_ALLOPEN_MODULE + ".jar";
 
   public static final String KOTLIN_HOME = "kotlin_home";
   public static final String KOTLIN_HOME_LOCATION =
       OkBuckGradlePlugin.WORKSPACE_PATH + "/" + KOTLIN_HOME;
   public static final String KOTLIN_HOME_TARGET = "//" + KOTLIN_HOME_LOCATION + ":" + KOTLIN_HOME;
   public static final String KOTLIN_KAPT_PLUGIN = "kotlin-kapt";
-  public static final String KOTLIN_HOME_BASE = "/libexec/lib";
-  public static final String KOTLIN_LIBRARIES_LOCATION =
-      "buck-out/gen" + "/" + KOTLIN_HOME_LOCATION + "/" + KOTLIN_HOME + KOTLIN_HOME_BASE;
-  private static final String KOTLIN_GROUP = "org.jetbrains.kotlin";
-  private static final String KOTLIN_GRADLE_MODULE = "kotlin-gradle-plugin";
-  private static final String KOTLIN_DEPS_CONFIG = "okbuck_kotlin_deps";
-  private static final String KOTLIN_EMBEDDABLE_COMPILER = "kotlin-compiler-embeddable";
-  private static final String KOTLIN_EMBEDDABLE_COMPILER_RULE_NAME = "kotlin_compiler_embeddable";
 
-  private static final ImmutableList<String> kotlinModules =
-      ImmutableList.of(
-          KOTLIN_EMBEDDABLE_COMPILER,
-          "kotlin-stdlib",
-          KOTLIN_ANDROID_EXTENSIONS_MODULE,
-          KOTLIN_ALLOPEN_MODULE,
-          "kotlin-reflect",
-          "kotlin-script-runtime",
-          "kotlin-annotation-processing-gradle",
-          "kotlin-gradle-plugin-api",
-          "kotlin-stdlib-common");
+  private static final String KOTLIN_AE_NAME = "android-extensions-compiler";
+  public static final String KOTLIN_AE_PLUGIN_TARGET =
+      "//" + KOTLIN_HOME_LOCATION + ":" + KOTLIN_AE_NAME + ".jar";
 
-  private static final ImmutableSet<String> embeddableCompilerJars =
-      ImmutableSet.of(KOTLIN_EMBEDDABLE_COMPILER + ".jar", "trove4j.jar", "annotations.jar");
+  private static final String KOTLIN_AO_NAME = "allopen-compiler-plugin";
+  public static final String KOTLIN_AO_PLUGIN_TARGET =
+      "//" + KOTLIN_HOME_LOCATION + ":" + KOTLIN_AO_NAME + ".jar";
+
+  public static final String COPY_COMMAND = "cp $(location :kotlin_home)/lib/%s.jar $OUT";
 
   private final Project project;
   private final BuckFileManager buckFileManager;
 
   private boolean kotlinHomeEnabled;
-  @Nullable private String kotlinVersion;
-  @Nullable private Set<OExternalDependency> dependencies;
+  @Nullable private KotlinExtension kotlinExtension;
 
   public KotlinManager(Project project, BuckFileManager buckFileManager) {
     this.project = project;
     this.buckFileManager = buckFileManager;
   }
 
-  @Nullable
-  public static String getDefaultKotlinVersion(Project project) {
-    return ProjectUtil.findVersionInClasspath(project, KOTLIN_GROUP, KOTLIN_GRADLE_MODULE);
-  }
-
-  @SuppressWarnings("ResultOfMethodCallIgnored")
-  public void setupKotlinHome(String kotlinVersion) {
+  public void setupKotlinHome(KotlinExtension kotlinExtension) {
     this.kotlinHomeEnabled = true;
-    this.kotlinVersion = kotlinVersion;
-
-    Configuration kotlinConfig = project.getConfigurations().maybeCreate(KOTLIN_DEPS_CONFIG);
-    DependencyHandler handler = project.getDependencies();
-    kotlinModules
-        .stream()
-        .map(module -> String.format("%s:%s:%s", KOTLIN_GROUP, module, kotlinVersion))
-        .forEach(dependency -> handler.add(KOTLIN_DEPS_CONFIG, dependency));
-
-    dependencies =
-        new DependencyCache(project, ProjectUtil.getDependencyManager(project)).build(kotlinConfig);
+    this.kotlinExtension = kotlinExtension;
   }
 
   public void finalizeDependencies() {
@@ -96,40 +58,38 @@ public final class KotlinManager {
       return;
     }
 
-    if (kotlinVersion == null) {
+    if (kotlinExtension == null || kotlinExtension.version == null) {
       throw new IllegalStateException("kotlinVersion is not setup");
     }
 
-    if (dependencies != null && dependencies.size() > 0) {
-      TreeMap<String, String> targetsNameMap = new TreeMap<>();
-      ImmutableList.Builder<String> embeddableCompilerDepsBuilder = ImmutableList.builder();
-      dependencies.forEach(
-          externalDependency -> {
-            if (!embeddableCompilerJars.contains(externalDependency.getVersionlessTargetName())) {
-              targetsNameMap.put(
-                  BuckRuleComposer.external(externalDependency),
-                  externalDependency.getVersionlessTargetName());
-            } else {
-              embeddableCompilerDepsBuilder.add(BuckRuleComposer.external(externalDependency));
-            }
-          });
+    Rule downloadRule =
+        new HttpArchive()
+            .sha256(kotlinExtension.getCompilerZipSha256())
+            .urls(ImmutableList.of(kotlinExtension.getCompilerZipDownloadUrl()))
+            .stripPrefix("kotlinc")
+            .type("zip")
+            .name(KOTLIN_HOME);
 
-      Rule embeddableCompilerRule =
-          new JvmBinaryRule()
-              .deps(embeddableCompilerDepsBuilder.build())
-              .name(KOTLIN_EMBEDDABLE_COMPILER_RULE_NAME)
-              .ruleType(RuleType.JAVA_BINARY.getBuckName());
+    ImmutableList<Rule> rules =
+        new ImmutableList.Builder<Rule>()
+            .add(downloadRule)
+            .addAll(getRules(KOTLIN_AE_NAME))
+            .addAll(getRules(KOTLIN_AO_NAME))
+            .build();
 
-      targetsNameMap.put(embeddableCompilerRule.buckName(), KOTLIN_EMBEDDABLE_COMPILER + ".jar");
+    buckFileManager.writeToBuckFile(rules, path.resolve(OkBuckGradlePlugin.BUCK).toFile());
+  }
 
-      Rule symlinkRule =
-          new SymlinkBuckFile()
-              .targetsNameMap(targetsNameMap)
-              .base(KOTLIN_HOME_BASE)
-              .name(KOTLIN_HOME);
-      buckFileManager.writeToBuckFile(
-          ImmutableList.of(embeddableCompilerRule, symlinkRule),
-          path.resolve(OkBuckGradlePlugin.BUCK).toFile());
-    }
+  private static ImmutableList<Rule> getRules(String name) {
+    return ImmutableList.of(
+        new Genrule()
+            .cmd(String.format(COPY_COMMAND, name))
+            .out(name + "__copy.jar")
+            .name(name + "__copy"),
+        new NativePrebuilt()
+            .prebuiltType(RuleType.PREBUILT_JAR.getProperties().get(0))
+            .prebuilt(":" + name + "__copy")
+            .ruleType(RuleType.PREBUILT_JAR.getBuckName())
+            .name(name + ".jar"));
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/ManifestMergerManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/ManifestMergerManager.java
@@ -13,6 +13,7 @@ import com.uber.okbuck.template.core.Rule;
 import com.uber.okbuck.template.java.NativePrebuilt;
 import com.uber.okbuck.template.jvm.JvmBinaryRule;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -69,6 +70,9 @@ public final class ManifestMergerManager {
   }
 
   public void finalizeDependencies() {
+    Path path = rootProject.file(MANIFEST_MERGER_BUCK_FILE).toPath();
+    FileUtil.deleteQuietly(path);
+
     if (dependencies != null && dependencies.size() > 0) {
       FileUtil.copyResourceToProject(
           "manifest/" + MANIFEST_MERGER_CLI_JAR,

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidInstrumentationTarget.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/android/AndroidInstrumentationTarget.java
@@ -52,6 +52,7 @@ public abstract class AndroidInstrumentationTarget extends AndroidAppTarget {
         .customOptions(JAVA_COMPILER_EXTRA_ARGUMENTS, getJavaCompilerOptions(getBaseVariant()))
         .customOptions(KOTLIN_COMPILER_EXTRA_ARGUMENTS, getKotlinCompilerOptions())
         .customOptions(getKotlinFriendPaths(false))
+        .customOptions(KOTLIN_COMPILER_PLUGINS, getKotlinCompilerPlugins())
         .build();
   }
 

--- a/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
@@ -108,7 +108,7 @@ public class OkBuckTask extends DefaultTask {
 
     // Fetch Kotlin deps if needed
     if (kotlinExtension.version != null) {
-      ProjectUtil.getKotlinManager(getProject()).setupKotlinHome(kotlinExtension.version);
+      ProjectUtil.getKotlinManager(getProject()).setupKotlinHome(kotlinExtension);
     }
 
     generate(

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/KotlinExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/KotlinExtension.java
@@ -1,6 +1,5 @@
 package com.uber.okbuck.extension;
 
-import com.uber.okbuck.core.manager.KotlinManager;
 import javax.annotation.Nullable;
 import org.gradle.api.Project;
 
@@ -9,7 +8,22 @@ public class KotlinExtension {
   /** Version of the kotlin compiler to use. */
   @Nullable public String version;
 
+  /** Sha256 of the compiler zip. */
+  @Nullable public String compilerZipSha256;
+
   KotlinExtension(Project project) {
-    version = KotlinManager.getDefaultKotlinVersion(project);
+    this.version = "3.72.0";
+    this.compilerZipSha256 = "ccd0db87981f1c0e3f209a1a4acb6778f14e63fe3e561a98948b5317e526cc6c";
+  }
+
+  public String getCompilerZipDownloadUrl() {
+    return String.format(
+        "https://github.com/JetBrains/kotlin/releases/download/v%s/kotlin-compiler-%s.zip",
+        this.version, this.version);
+  }
+
+  @Nullable
+  public String getCompilerZipSha256() {
+    return this.compilerZipSha256;
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
@@ -83,7 +83,7 @@ public class OkBuckExtension {
   /** The prebuilt buck binary to use */
   @Input
   public String buckBinary =
-      "com.github.facebook:buck:f6578801138a7b6b89d4a485dd2d0c740fdefe8a@pex";
+      "com.github.facebook:buck:0aeb8be606590c8203827a20dfa3c7f14a12fb5d@pex";
 
   private WrapperExtension wrapperExtension = new WrapperExtension();
   private KotlinExtension kotlinExtension;

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/common/Genrule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/common/Genrule.rocker.raw
@@ -1,0 +1,17 @@
+@args (
+    String out,
+    String cmd,
+)
+
+genrule(
+    name = "@name",
+    out = "@out",
+    cmd = "@cmd",
+@if (valid(visibility)) {
+    visibility = [
+    @for (v : visibility) {
+        "@v",
+    }
+    ],
+}
+)

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/common/HttpArchive.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/common/HttpArchive.rocker.raw
@@ -1,0 +1,23 @@
+@import java.util.Collection
+
+@args (
+    String sha256,
+    String stripPrefix,
+    String type,
+    Collection urls,
+)
+
+http_archive(
+    name = "@(name)",
+    sha256 = "@(sha256)",
+@if (valid(stripPrefix)) {
+    strip_prefix = "@(stripPrefix)",
+}
+    type = "@(type)",
+    urls = [
+    @for (url : sorted(urls)) {
+        "@url",
+    }
+    ],
+    visibility = ["PUBLIC"],
+)

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -57,6 +57,7 @@ def build = [
         jnaPlatform      : "net.java.dev.jna:jna-platform:${versions.jna}",
         mavenArtifact    : "org.apache.maven:maven-artifact:3.6.2",
         proguard         : "net.sf.proguard:proguard-base:6.2.2",
+        guava            : "com.google.guava:guava:29.0-jre",
 ]
 
 def buildConfig = [
@@ -97,7 +98,7 @@ def external = [
         saxon           : "net.sf.saxon:Saxon-HE:10.1",
         scalaLibrary    : "org.scala-lang:scala-library:2.13.3",
         log4j           : exclude("log4j:log4j:1.2.15", "jline", "jms", "jmxtools", "jmxri"),
-        guava           : "com.google.guava:guava:26.0-jre",
+        guava           : "com.google.guava:guava:29.0-android",
 ]
 
 def lint = [

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -57,7 +57,6 @@ def build = [
         jnaPlatform      : "net.java.dev.jna:jna-platform:${versions.jna}",
         mavenArtifact    : "org.apache.maven:maven-artifact:3.6.2",
         proguard         : "net.sf.proguard:proguard-base:6.2.2",
-        guava            : "com.google.guava:guava:29.0-jre",
 ]
 
 def buildConfig = [
@@ -98,7 +97,7 @@ def external = [
         saxon           : "net.sf.saxon:Saxon-HE:10.1",
         scalaLibrary    : "org.scala-lang:scala-library:2.13.3",
         log4j           : exclude("log4j:log4j:1.2.15", "jline", "jms", "jmxtools", "jmxri"),
-        guava           : "com.google.guava:guava:29.0-android",
+        guava           : "com.google.guava:guava:29.0-jre",
 ]
 
 def lint = [

--- a/kotlin-app/build.gradle
+++ b/kotlin-app/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation deps.external.daggerAndroid
     implementation deps.external.gson
     implementation deps.external.sqldelight
+    implementation deps.external.guava
 
     kapt deps.apt.daggerCompiler
     kapt deps.apt.daggerAndroidProcessor


### PR DESCRIPTION
- Update to latest version of Buck master
- Use kotlin compiler zip (downloaded from github) which contains all the jars and is what is used by buck now
- Use `kotlinc_plugins` to define kotlin plugins which supports source path now.