### PR TITLE
Add .okbuck.buckconfig to .buckconfig

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,3 +1,5 @@
+<file:.okbuck/config/okbuck.buckconfig>
+
 [project]
     allow_symlinks = forbid
     ide = intellij
@@ -48,5 +50,3 @@
 
 [scala]
     target_level = jvm-1.8
-
-<file:.okbuck/config/okbuck.buckconfig>

--- a/buckw
+++ b/buckw
@@ -225,10 +225,6 @@ setupBuckRun ( ) {
     fi
 }
 
-setupBuckFlags ( ) {
-    EXTRA_BUCK_CONFIG="$EXTRA_BUCK_CONFIG --config-file .okbuck/config/okbuck.buckconfig"
-}
-
 # Handle parameters and flags
 handleParams ( ) {
    SKIP_FLAGS=""
@@ -239,11 +235,6 @@ handleParams ( ) {
        --version) export SKIP_FLAGS=1;;
        esac;
    done
-
-   if [[ -z "$SKIP_FLAGS" ]]; then
-       # --help|-h|help|kill|--version do not support --config-file
-       setupBuckFlags
-   fi
 }
 
 handleParams "$@"

--- a/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
@@ -7,6 +7,7 @@ import static com.uber.okbuck.OkBuckGradlePlugin.OKBUCK_TARGETS_FILE;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
+import com.google.errorprone.annotations.Var;
 import com.uber.okbuck.OkBuckGradlePlugin;
 import com.uber.okbuck.composer.base.BuckRuleComposer;
 import com.uber.okbuck.core.dependency.OExternalDependency;
@@ -16,6 +17,7 @@ import com.uber.okbuck.core.manager.KotlinManager;
 import com.uber.okbuck.core.manager.ScalaManager;
 import com.uber.okbuck.core.model.base.ProjectType;
 import com.uber.okbuck.core.model.base.RuleType;
+import com.uber.okbuck.core.util.FileUtil;
 import com.uber.okbuck.core.util.ProguardUtil;
 import com.uber.okbuck.core.util.ProjectUtil;
 import com.uber.okbuck.extension.ExternalDependenciesExtension;
@@ -258,6 +260,17 @@ public class OkBuckTask extends DefaultTask {
                         .getExternalDependenciesExtension()
                         .getGenerateMavenRepositories()))
         .render(okbuckBuckConfig());
+
+    // Add entry of OkBuckBuckConfig to DotBuckConfig
+    String entry =
+        String.format(
+            "<file:%s>", FileUtil.getRelativePath(getProject().getRootDir(), okbuckBuckConfig()));
+
+    @Var String dotBuckContent = FileUtil.readString(dotBuckConfig());
+    if (!dotBuckContent.contains(entry)) {
+      dotBuckContent = entry + "\n\n" + dotBuckContent;
+      FileUtil.writeString(dotBuckConfig(), dotBuckContent);
+    }
   }
 
   private LinkedHashMap<String, String> repositoryMap(boolean downloadInBuck) {

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/FileUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/FileUtil.java
@@ -45,6 +45,22 @@ public final class FileUtil {
     }
   }
 
+  public static String readString(File f) {
+    try {
+      return new String(Files.readAllBytes(f.toPath()), UTF_8);
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to read from file " + f + " due to exception: " + e);
+    }
+  }
+
+  public static void writeString(File f, String content) {
+    try {
+      Files.write(f.toPath(), content.getBytes(UTF_8));
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to write to file " + f + " due to exception: " + e);
+    }
+  }
+
   public static void copyResourceToProject(String resource, File destination) {
     try {
       FileUtils.copyURLToFile(FileUtil.class.getResource(resource), destination);

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
@@ -15,7 +15,7 @@ import org.gradle.api.tasks.Input;
 @SuppressWarnings("unused")
 public class OkBuckExtension {
 
-  private static final String DEFAULT_BUCK_BINARY_SHA = "0299f0ff54201b700c06f8892862e1109d9739eb";
+  private static final String DEFAULT_BUCK_BINARY_SHA = "a68ef0d834eec5fe381cb3e8e8612ba9fa42a09d";
 
   /** Build Tools Version */
   @Input public String buildToolVersion = "28.0.2";
@@ -83,9 +83,7 @@ public class OkBuckExtension {
   @Input public boolean legacyAnnotationProcessorSupport = true;
 
   /** The prebuilt buck binary to use */
-  @Input
-  public String buckBinary =
-      "com.github.facebook:buck:" + DEFAULT_BUCK_BINARY_SHA + "@pex";
+  @Input public String buckBinary = "com.github.facebook:buck:" + DEFAULT_BUCK_BINARY_SHA + "@pex";
 
   /** The prebuilt buck binary to use with java 11 */
   @Input

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckWrapper.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/BuckWrapper.rocker.raw
@@ -222,10 +222,6 @@ setupBuckRun ( ) {
     fi
 }
 
-setupBuckFlags ( ) {
-    EXTRA_BUCK_CONFIG="$EXTRA_BUCK_CONFIG --config-file .okbuck/config/okbuck.buckconfig"
-}
-
 # Handle parameters and flags
 handleParams ( ) {
    SKIP_FLAGS=""
@@ -236,11 +232,6 @@ handleParams ( ) {
        --version) export SKIP_FLAGS=1;;
        esac;
    done
-
-   if [[ -z "$SKIP_FLAGS" ]]; then
-       # --help|-h|help|kill|--version do not support --config-file
-       setupBuckFlags
-   fi
 }
 
 handleParams "$@@"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 // CI keeps gradle home cached based on the SHA of this file.
 // Update below to invalidate the cache.
-// Gradle Cache Version 3
+// Gradle Cache Version 4
 
 def exclude = { dep, String... excludes  ->
     return dependencies.create(dep) {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -24,7 +24,7 @@ def versions = [
         butterKnife        : "10.2.1",
         dagger             : "2.28.3",
         jna                : "5.6.0",
-        kotlin             : "1.3.72",
+        kotlin             : "1.4.10",
         leakCanary         : "1.5.4",
         rocker             : "1.3.0",
         support            : "28.0.0",

--- a/kotlin-app/src/test/java/com/uber/okbuck/example/Coffee.kt
+++ b/kotlin-app/src/test/java/com/uber/okbuck/example/Coffee.kt
@@ -83,4 +83,5 @@ interface CoffeeShop {
 fun main(args: Array<String>) {
     val coffee = DaggerCoffeeShop.builder().build()
     coffee.maker().brew()
+    println(args)
 }

--- a/libraries/kotlinlibrary/src/main/java/demo/helloWorld.kt
+++ b/libraries/kotlinlibrary/src/main/java/demo/helloWorld.kt
@@ -11,6 +11,7 @@ fun getGreeting(): String {
 }
 
 fun main(args: Array<String>) {
+    println(args)
     println(getGreeting())
     println(JavaClass().foo)
 }


### PR DESCRIPTION
Don't pass okbuck.buckconfig explicity to buck in the
buckwrapper to allow overriding configs in .okbuck.buckconfig

Bump Kotlin to 1.4.10 and incorporate Subplugin changes

Bump buck to a68ef0d834eec5fe381cb3e8e8612ba9fa42a09d. The latest version 
has changes to kotlin params which will require further changes when updating.

Resolves https://github.com/uber/okbuck/issues/927