### PR TITLE
Add support for generating http_file rules for bazel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ buildSrc/bintray.properties
 # Bazel
 bazel-*
 .ijwb
+BUILD.bazel

--- a/buildSrc/src/main/java/com/uber/okbuck/OkBuckGradlePlugin.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/OkBuckGradlePlugin.java
@@ -74,7 +74,8 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
       "//" + DOT_OKBUCK + "/defs:" + OKBUCK_TARGETS_BZL;
 
   private static final String OKBUCK_PREBUILT_BZL = "okbuck_prebuilt.bzl";
-  public static final String OKBUCK_PREBUILT_FILE = DOT_OKBUCK + "/defs/" + OKBUCK_PREBUILT_BZL;
+  public static final String OKBUCK_PREBUILT_FOLDER = DOT_OKBUCK + "/defs";
+  public static final String OKBUCK_PREBUILT_FILE = OKBUCK_PREBUILT_FOLDER + "/" + OKBUCK_PREBUILT_BZL;
   public static final String OKBUCK_PREBUILT_TARGET =
       "//" + DOT_OKBUCK + "/defs:" + OKBUCK_PREBUILT_BZL;
 

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/common/BazelHttpFileRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/common/BazelHttpFileRuleComposer.java
@@ -1,0 +1,53 @@
+package com.uber.okbuck.composer.common;
+
+import com.google.common.base.Preconditions;
+import com.uber.okbuck.core.dependency.OExternalDependency;
+import com.uber.okbuck.core.model.base.RuleType;
+import com.uber.okbuck.template.common.BazelHttpFile;
+import com.uber.okbuck.template.core.Rule;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BazelHttpFileRuleComposer {
+
+  private BazelHttpFileRuleComposer() {}
+
+  /**
+   * @param dependencies External Dependencies whose http file rule needs to be created
+   * @return List of rules
+   */
+  public static List<Rule> compose(
+      Collection<OExternalDependency> dependencies, HashMap<String, String> shaSum256) {
+    return dependencies
+        .stream()
+        .sorted(OExternalDependency.compareByName)
+        .map(
+            dependency -> {
+              String sha256Key =
+                  OExternalDependency.getGradleSha(dependency.getRealDependencyFile());
+              String sha256 = Preconditions.checkNotNull(shaSum256.get(sha256Key));
+
+              BazelHttpFile rule =
+                  new BazelHttpFile()
+                      .mavenCoords(dependency.getMavenCoords())
+                      .sha256(sha256);
+
+              dependency
+                  .getRealSourceFile()
+                  .ifPresent(
+                      file -> {
+                        String sourcesSha256Key = OExternalDependency.getGradleSha(file);
+                        String sourcesSha256 =
+                            Preconditions.checkNotNull(shaSum256.get(sourcesSha256Key));
+                        rule.sourcesSha256(sourcesSha256);
+                      });
+
+              rule.ruleType(RuleType.HTTP_FILE.getBuckName());
+              return rule;
+            })
+        .collect(Collectors.toList());
+  }
+}

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/OExternalDependency.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/OExternalDependency.java
@@ -38,6 +38,7 @@ public class OExternalDependency {
   public static Comparator<OExternalDependency> compareByName =
       (o1, o2) ->
           ComparisonChain.start()
+              .compare(o1.base.basePath(), o2.base.basePath())
               .compare(o1.getPackaging(), o2.getPackaging())
               .compare(o1.getTargetName(), o2.getTargetName())
               .result();

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/BuckFileManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/BuckFileManager.java
@@ -1,7 +1,11 @@
 package com.uber.okbuck.core.manager;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
+import com.google.common.io.CharSink;
+import com.google.common.io.FileWriteMode;
+import com.google.common.io.Files;
 import com.uber.okbuck.OkBuckGradlePlugin;
 import com.uber.okbuck.core.model.base.RuleType;
 import com.uber.okbuck.extension.RuleOverridesExtension;
@@ -29,6 +33,21 @@ public class BuckFileManager {
 
   public BuckFileManager(RuleOverridesExtension ruleOverridesExtension) {
     this.ruleOverridesExtension = ruleOverridesExtension;
+  }
+
+  public void writeToBuckFile(String content, File buckFile, boolean append) {
+    CharSink sink;
+    if (append) {
+      sink = Files.asCharSink(buckFile, Charsets.UTF_8, FileWriteMode.APPEND);
+    } else {
+      sink = Files.asCharSink(buckFile, Charsets.UTF_8);
+    }
+
+    try {
+      sink.write(content);
+    } catch (IOException e) {
+      throw new IllegalStateException("Couldn't create the buck file", e);
+    }
   }
 
   public void writeToBuckFile(List<Rule> rules, File buckFile) {

--- a/buildSrc/src/main/java/com/uber/okbuck/core/model/base/RuleType.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/model/base/RuleType.java
@@ -35,7 +35,9 @@ public enum RuleType {
   PREBUILT_JAR("binary_jar"),
   PREBUILT,
   PREBUILT_NATIVE_LIBRARY,
-  ROBOLECTRIC_TEST("java");
+  ROBOLECTRIC_TEST("java"),
+  OKBUCK_PREBUILT,
+  HTTP_FILE;
 
   private final ImmutableList<String> properties;
 

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/ExternalDependenciesExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/ExternalDependenciesExtension.java
@@ -59,6 +59,11 @@ public class ExternalDependenciesExtension {
    */
   @Input private Set<String> dynamicDependenciesToIgnore = new HashSet<>();
 
+  /**
+   * Set to true to enable creation of http_file rules needed by bazel build system
+   */
+  @Input private boolean bazelDeps = false;
+
   @Nullable private Set<VersionlessDependency> allowAllVersionsSet;
 
   public ExternalDependenciesExtension() {}
@@ -156,5 +161,9 @@ public class ExternalDependenciesExtension {
 
   public Set<String> getDynamicDependenciesToIgnore() {
     return dynamicDependenciesToIgnore;
+  }
+
+  public boolean bazelDepsEnabled() {
+    return bazelDeps;
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/RuleOverridesExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/RuleOverridesExtension.java
@@ -63,6 +63,7 @@ public class RuleOverridesExtension {
       ImmutableMap.<RuleType, String>builder()
           .put(RuleType.AIDL, OKBUCK_TARGETS_TARGET)
           .put(RuleType.PREBUILT, OKBUCK_PREBUILT_TARGET)
+          .put(RuleType.HTTP_FILE, OKBUCK_PREBUILT_TARGET)
           .put(RuleType.PREBUILT_JAR, OKBUCK_TARGETS_TARGET)
           .put(RuleType.ANDROID_LIBRARY, OKBUCK_TARGETS_TARGET)
           .put(RuleType.ANDROID_MODULE, OKBUCK_ANDROID_MODULES_TARGET)

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/common/BazelFunctionRule.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/common/BazelFunctionRule.rocker.raw
@@ -1,0 +1,1 @@
+def load_http_files():

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/common/BazelHttpFile.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/common/BazelHttpFile.rocker.raw
@@ -1,0 +1,8 @@
+@option discardLogicWhitespace=false
+@import java.util.Collection
+@args (
+    String ruleType,
+    String mavenCoords,
+    String sha256,
+    String sourcesSha256,
+)    @(ruleType)(maven_coords = "@(mavenCoords)", sha256 = "@(sha256)"@if (valid(sourcesSha256)) {, sources_sha256 = "@(sourcesSha256)"})

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/OkbuckPrebuilt.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/OkbuckPrebuilt.rocker.raw
@@ -1,17 +1,19 @@
 @args (
+String okbuckPrebuiltRule,
 String prebuiltJarRule,
 String prebuiltAarRule,
 String strictVisibilityScope,
 )
 
-def okbuck_prebuilt(
+def @(okbuckPrebuiltRule)(
         name,
         maven_coords,
         sha256,
         sources_sha256 = None,
         deps = None,
         enable_jetifier = False,
-        first_level = False):
+        first_level = False,
+        testonly = False):
     if deps == None:
         deps = []
 


### PR DESCRIPTION
Below will generate `defs.bzl` containing Bazel http_file rules to enable downloading of 3rdparty deps.

```
okbuck {
  externalDependecies {
     bazelDeps = true
  }
}
```