### PR TITLE
Add ability to configure okbuck buckconfig inclusion

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/task/OkBuckTask.java
@@ -273,15 +273,17 @@ public class OkBuckTask extends DefaultTask {
                         .getGenerateMavenRepositories()))
         .render(okbuckBuckConfig());
 
-    // Add entry of OkBuckBuckConfig to DotBuckConfig
-    String entry =
-        String.format(
-            "<file:%s>", FileUtil.getRelativePath(getProject().getRootDir(), okbuckBuckConfig()));
+    if (okbuckExt.okBuckBuckConfig) {
+      // Add entry of OkBuckBuckConfig to DotBuckConfig
+      String entry =
+          String.format(
+              "<file:%s>", FileUtil.getRelativePath(getProject().getRootDir(), okbuckBuckConfig()));
 
-    @Var String dotBuckContent = FileUtil.readString(dotBuckConfig());
-    if (!dotBuckContent.contains(entry)) {
-      dotBuckContent = entry + "\n\n" + dotBuckContent;
-      FileUtil.writeString(dotBuckConfig(), dotBuckContent);
+      @Var String dotBuckContent = FileUtil.readString(dotBuckConfig());
+      if (!dotBuckContent.contains(entry)) {
+        dotBuckContent = entry + "\n\n" + dotBuckContent;
+        FileUtil.writeString(dotBuckConfig(), dotBuckContent);
+      }
     }
   }
 

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
@@ -53,6 +53,9 @@ public class OkBuckExtension {
   /** Name of the build file where generated build rules will be written. */
   @Input public String buildFileName = "BUCK";
 
+  /** Whether to add OkBuckBuckConfig to top level .buckconfig */
+  @Input public boolean okBuckBuckConfig = true;
+
   /** Extra buck options */
   @Input public Map<String, Map<String, Collection<String>>> extraBuckOpts = new HashMap<>();
 


### PR DESCRIPTION
<!--
Thank you for contributing to okbuck. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
This allows one to configure the inclusion of `.okbuck.buckconfig` to top level `.buckconfig`. The default is to always include it if it is not present
