### PR TITLE
Rebase release branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,7 +224,7 @@ okbuck {
     externalDependencies {
         resolutionAction = "latest"
         allowAllVersions = [
-                "org.robolectric:android-all",
+                "org.robolectric:android-all-instrumented",
         ]
         autoValueConfigurations = [
             "autoValueAnnotations",

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/RobolectricManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/RobolectricManager.java
@@ -52,10 +52,13 @@ public final class RobolectricManager {
       apisToDownload = EnumSet.allOf(API.class);
     }
 
+    String preinstrumentedVersion =
+        ProjectUtil.getOkBuckExtension(rootProject).getTestExtension().robolectricPreinstrumentedVersion;
+
     for (API api : apisToDownload) {
       Configuration runtimeApi =
           rootProject.getConfigurations().maybeCreate(ROBOLECTRIC_RUNTIME + "_" + api.name());
-      rootProject.getDependencies().add(runtimeApi.getName(), api.getCoordinates());
+      rootProject.getDependencies().add(runtimeApi.getName(), api.getCoordinates(preinstrumentedVersion));
       runtimeDeps.add(runtimeApi);
     }
 
@@ -116,10 +119,10 @@ public final class RobolectricManager {
     API_25("7.1.0_r7", "r1"),
     API_26("8.0.0_r4", "r1"),
     API_27("8.1.0", "4611349"),
-    API_P("P", "4651975"),
     API_28("9", "4913185-2"),
     API_29("10", "5803371"),
-    API_30("11", "6757853");
+    API_30("11", "6757853"),
+    API_31("12", "7732740");
 
     private final String androidVersion;
     private final String frameworkSdkBuildVersion;
@@ -129,11 +132,13 @@ public final class RobolectricManager {
       this.frameworkSdkBuildVersion = frameworkSdkBuildVersion;
     }
 
-    String getCoordinates() {
-      return "org.robolectric:android-all:"
+    String getCoordinates(String preinstrumentedVersion) {
+      return "org.robolectric:android-all-instrumented:"
           + androidVersion
           + "-robolectric-"
-          + frameworkSdkBuildVersion;
+          + frameworkSdkBuildVersion
+          + "-"
+          + preinstrumentedVersion;
     }
 
     static API from(String apiLevel) {
@@ -166,8 +171,8 @@ public final class RobolectricManager {
           return API_29;
         case "30":
           return API_30;
-        case "P":
-          return API_P;
+        case "31":
+          return API_31;
         default:
           throw new IllegalStateException("Unknown Robolectric API Level: " + apiLevel);
       }

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/ExternalDependenciesExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/ExternalDependenciesExtension.java
@@ -46,7 +46,7 @@ public class ExternalDependenciesExtension {
    * dependencies like robolectric runtime deps.
    */
   @Input
-  private List<String> allowAllVersions = Collections.singletonList("org.robolectric:android-all");
+  private List<String> allowAllVersions = Collections.singletonList("org.robolectric:android-all-instrumented");
 
   /**
    * Stores the dependency versions to be used for dynamic notations that have , or + in their

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/TestExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/TestExtension.java
@@ -13,6 +13,13 @@ public class TestExtension {
    */
   @Nullable public Set<String> robolectricApis = null;
 
+  /**
+   * Specify the preinstrumented version of artifacts to be used.
+   * Hardcoded in Robolectric
+   * https://github.com/robolectric/robolectric/blob/master/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java#L50
+   */
+  public String robolectricPreinstrumentedVersion = "i3";
+
   /** Enable generation of espresso test rules. */
   public boolean espresso = false;
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -129,7 +129,7 @@ def test = [
         junit         : "junit:junit:4.13.2",
         kotlinTest    : "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}",
         mockito       : "org.mockito:mockito-core:3.8.0",
-        robolectric   : "org.robolectric:robolectric:4.5.1",
+        robolectric   : "org.robolectric:robolectric:4.7.3",
         scalaTest     : "org.scalatest:scalatest_sjs1_2.13:3.2.0",
         scalaTestJunit: "org.scalatestplus:junit-4-12_2.13:3.2.2.0",
         testExt       : "androidx.test.ext:junit:1.1.2-rc01",


### PR DESCRIPTION
Rebasing master on release to include Robolectric 4.7.3 and preinstrumented jars (#958).

We should be able to kill the release branch after this since a path to gradle 7 is unlocked in uber internal monorepos