### PR TITLE
Upgrade Jetifier to 1.0.0-beta03

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/extension/JetifierExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/JetifierExtension.java
@@ -13,7 +13,7 @@ import org.gradle.api.Project;
 
 public class JetifierExtension {
 
-  public static final String DEFAULT_JETIFIER_VERSION = "1.0.0-beta02";
+  public static final String DEFAULT_JETIFIER_VERSION = "1.0.0-beta03";
 
   /**
    * This is the mandatory dependencies to be excluded from being jetified, as the jetifier rule


### PR DESCRIPTION
<!--
Thank you for contributing to okbuck. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
The current Jetifier Preprocessor version specified in the tooling has a bug in the default rules which changes the constant values as well. A specific use case is:
_android.support.customtabs.action.CustomTabsService_ to _androidx.support.customtabs.action.CustomTabsService_

The issue was reported in the Android AOSP  -> https://android-review.googlesource.com/875343/. It has been fixed in the Jetifier version 1.0.0-beta03. 

**Change Log**:
https://developer.android.com/jetpack/androidx/releases/jetifier#1.0.0-beta03

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:
https://android-review.googlesource.com/c/platform/frameworks/support/+/875343/
