### PR TITLE
feat: Add support for exporting raw dependencies

### DIFF
--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.uber
-VERSION_NAME=0.53.0-SNAPSHOT
+VERSION_NAME=0.53.1-SNAPSHOT
 POM_DESCRIPTION=A Gradle plugin that lets developers utilize the Buck build system on a Gradle project
 POM_URL=https://github.com/uber/okbuck/
 POM_SCM_URL=https://github.com/uber/okbuck/

--- a/buildSrc/src/main/java/com/uber/okbuck/OkBuckGradlePlugin.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/OkBuckGradlePlugin.java
@@ -162,7 +162,7 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
               new AnnotationProcessorCache(rootBuckProject, buckFileManager, processorBuildFile);
 
           // Create Dependency manager
-          dependencyManager = new DependencyManager(rootBuckProject, okbuckExt, buckFileManager, createDependencyExporter(rootBuckProject));
+          dependencyManager = new DependencyManager(rootBuckProject, okbuckExt, buckFileManager, createDependencyExporter(okbuckExt));
 
           // Create Lint Manager
           String lintBuildFile = LINT_BUILD_FOLDER + "/" + okbuckExt.buildFileName;
@@ -386,12 +386,7 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
     }
   }
 
-  @Nullable
-  private static DependencyExporter createDependencyExporter(Project project){
-    boolean exportDependencies = ProjectUtil.getPropertyAsBoolean(project,"exportDependencies");
-    String exportDependenciesFile = ProjectUtil.getPropertyAsString(project, "exportDependenciesFile",
-        DOT_OKBUCK + "/raw-deps");
-
-    return new JsonDependencyExporter(Paths.get(project.getRootDir().getAbsolutePath(), exportDependenciesFile).toString(), exportDependencies);
+  private static DependencyExporter createDependencyExporter(OkBuckExtension okbuckExt){
+    return new JsonDependencyExporter(okbuckExt.getExportDependenciesExtension());
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/OkBuckGradlePlugin.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/OkBuckGradlePlugin.java
@@ -34,24 +34,21 @@ import com.uber.okbuck.generator.BuckFileGenerator;
 import com.uber.okbuck.template.common.ExportFile;
 import com.uber.okbuck.template.core.Rule;
 import com.uber.okbuck.wrapper.BuckWrapperTask;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.artifacts.Configuration;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import org.gradle.api.Plugin;
-import org.gradle.api.Project;
-import org.gradle.api.Task;
-import org.gradle.api.artifacts.Configuration;
-
-import javax.annotation.Nullable;
 
 // Dependency Tree
 //
@@ -162,7 +159,9 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
               new AnnotationProcessorCache(rootBuckProject, buckFileManager, processorBuildFile);
 
           // Create Dependency manager
-          dependencyManager = new DependencyManager(rootBuckProject, okbuckExt, buckFileManager, createDependencyExporter(okbuckExt));
+          dependencyManager =
+              new DependencyManager(
+                  rootBuckProject, okbuckExt, buckFileManager, createDependencyExporter(okbuckExt));
 
           // Create Lint Manager
           String lintBuildFile = LINT_BUILD_FOLDER + "/" + okbuckExt.buildFileName;
@@ -244,10 +243,7 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
                   wrapper.ignoredDirs);
 
           Map<String, Configuration> extraConfigurations =
-              okbuckExt
-                  .extraDepCachesMap
-                  .keySet()
-                  .stream()
+              okbuckExt.extraDepCachesMap.keySet().stream()
                   .collect(
                       Collectors.toMap(
                           Function.identity(),
@@ -321,9 +317,7 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
           rootOkBuckTask.dependsOn(okBuckClean);
 
           // Create okbuck task on each project to generate their buck file
-          okbuckExt
-              .buckProjects
-              .stream()
+          okbuckExt.buckProjects.stream()
               .filter(p -> p.getBuildFile().exists())
               .forEach(
                   bp -> {
@@ -344,9 +338,7 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
 
   private void writeExportedFileRules(Project rootBuckProject, OkBuckExtension okBuckExtension) {
     Set<String> currentProjectPaths =
-        okBuckExtension
-            .buckProjects
-            .stream()
+        okBuckExtension.buckProjects.stream()
             .filter(project -> ProjectUtil.getType(project) != ProjectType.UNKNOWN)
             .map(
                 project ->
@@ -375,9 +367,7 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
               .toFile();
       try (OutputStream os =
           new FileOutputStream(buckFile, currentProjectPaths.contains(entry.getKey()))) {
-        entry
-            .getValue()
-            .stream()
+        entry.getValue().stream()
             .sorted((rule1, rule2) -> rule1.name().compareToIgnoreCase(rule2.name()))
             .forEach(rule -> rule.render(os));
       } catch (IOException e) {
@@ -386,7 +376,7 @@ public class OkBuckGradlePlugin implements Plugin<Project> {
     }
   }
 
-  private static DependencyExporter createDependencyExporter(OkBuckExtension okbuckExt){
+  private static DependencyExporter createDependencyExporter(OkBuckExtension okbuckExt) {
     return new JsonDependencyExporter(okbuckExt.getExportDependenciesExtension());
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/exporter/DependencyExporter.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/exporter/DependencyExporter.java
@@ -1,0 +1,10 @@
+package com.uber.okbuck.core.dependency.exporter;
+
+import org.gradle.api.artifacts.ExternalDependency;
+
+import java.util.Set;
+
+public interface DependencyExporter {
+
+  void export(Set<ExternalDependency> dependencies);
+}

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/exporter/DependencyExporterModel.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/exporter/DependencyExporterModel.java
@@ -1,0 +1,71 @@
+package com.uber.okbuck.core.dependency.exporter;
+
+import org.gradle.api.artifacts.ExcludeRule;
+import org.gradle.api.artifacts.ExternalDependency;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+import java.util.TreeSet;
+
+public class DependencyExporterModel {
+
+  @Nullable
+  private final String name;
+  @Nullable
+  private final String version;
+  @Nullable
+  private final String group;
+  private final boolean force;
+  @Nullable
+  private final Set<String> excludeRules;
+  private final boolean transitive;
+
+  public DependencyExporterModel(ExternalDependency externalDependency) {
+    name = externalDependency.getName();
+    version = externalDependency.getVersion();
+    group = externalDependency.getGroup();
+    force = externalDependency.isForce();
+    transitive = externalDependency.isTransitive();
+
+    excludeRules = new TreeSet<>();
+
+    if (externalDependency.getExcludeRules() != null) {
+      for (ExcludeRule excludeRule : externalDependency.getExcludeRules()) {
+        if (excludeRule.getGroup() != null) {
+          excludeRules.add(excludeRule.getGroup());
+        }
+        if (excludeRule.getModule() != null) {
+          excludeRules.add(excludeRule.getModule());
+        }
+      }
+    }
+  }
+
+  @Nullable
+  public String getName() {
+    return name;
+  }
+
+  @Nullable
+  public String getVersion() {
+    return version;
+  }
+
+  @Nullable
+  public String getGroup() {
+    return group;
+  }
+
+  public boolean isForce() {
+    return force;
+  }
+
+  @Nullable
+  public Set<String> getExcludeRules() {
+    return excludeRules;
+  }
+
+  public boolean isTransitive() {
+    return transitive;
+  }
+}

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/exporter/DependencyExporterModel.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/exporter/DependencyExporterModel.java
@@ -10,36 +10,39 @@ import java.util.stream.Collectors;
 
 public class DependencyExporterModel {
 
-  @Nullable
-  private final String name;
-  @Nullable
-  private final String version;
-  @Nullable
-  private final String group;
+  @Nullable private final String name;
+  @Nullable private final String version;
+  @Nullable private final String group;
   private final boolean force;
-  @Nullable
-  private Set<String> excludeRules = new TreeSet<>();
-  private final boolean transitive;
+  @Nullable private Set<String> excludeRules = new TreeSet<>();
 
   public DependencyExporterModel(ExternalDependency externalDependency) {
     name = externalDependency.getName();
     version = externalDependency.getVersion();
     group = externalDependency.getGroup();
     force = externalDependency.isForce();
-    transitive = externalDependency.isTransitive();
 
     if (externalDependency.getExcludeRules() != null) {
-      excludeRules = externalDependency.getExcludeRules().stream().flatMap(e -> {
-        Set<String> set = new TreeSet<>();
-        if (StringUtils.isNotBlank(e.getGroup()) && StringUtils.isNotBlank(e.getModule())) {
-          set.add(String.format("%s:%s", e.getGroup(), e.getModule()));
-        } else if (StringUtils.isNotBlank(e.getGroup())) {
-          set.add(e.getGroup());
-        } else if (StringUtils.isNotBlank(e.getModule())) {
-          set.add(e.getModule());
-        }
-        return set.stream();
-      }).collect(Collectors.toSet());
+      excludeRules =
+          externalDependency.getExcludeRules()
+              .stream()
+              .map(
+                  e -> {
+                    if (StringUtils.isNotBlank(e.getGroup())
+                        && StringUtils.isNotBlank(e.getModule())) {
+                      return String.format("%s:%s", e.getGroup(), e.getModule());
+                    }
+
+                    if (StringUtils.isNotBlank(e.getGroup())) {
+                      return e.getGroup();
+                    }
+
+                    if (StringUtils.isNotBlank(e.getModule())) {
+                      return e.getModule();
+                    }
+                    return null;
+                  })
+              .collect(Collectors.toSet());
     }
   }
 
@@ -65,9 +68,5 @@ public class DependencyExporterModel {
   @Nullable
   public Set<String> getExcludeRules() {
     return excludeRules;
-  }
-
-  public boolean isTransitive() {
-    return transitive;
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/exporter/ExporterException.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/exporter/ExporterException.java
@@ -1,0 +1,10 @@
+package com.uber.okbuck.core.dependency.exporter;
+
+import java.io.IOException;
+
+public class ExporterException extends RuntimeException {
+
+  public ExporterException(IOException e) {
+    super(e);
+  }
+}

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/exporter/ExporterException.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/exporter/ExporterException.java
@@ -1,10 +1,7 @@
 package com.uber.okbuck.core.dependency.exporter;
 
-import java.io.IOException;
-
 public class ExporterException extends RuntimeException {
-
-  public ExporterException(IOException e) {
+  public ExporterException(Exception e) {
     super(e);
   }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/exporter/JsonDependencyExporter.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/exporter/JsonDependencyExporter.java
@@ -1,0 +1,47 @@
+package com.uber.okbuck.core.dependency.exporter;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.gradle.api.artifacts.ExternalDependency;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class JsonDependencyExporter implements DependencyExporter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JsonDependencyExporter.class);
+
+  private final String filePath;
+  private final boolean enable;
+
+  public JsonDependencyExporter(String filePath, boolean enable) {
+    this.filePath = filePath;
+    this.enable = enable;
+  }
+
+  @Override
+  public void export(Set<ExternalDependency> dependencies) {
+    if (!enable) {
+      LOG.info("Exporting dependencies is disabled");
+      return;
+    }
+
+    Set<DependencyExporterModel> dependencyModels = dependencies.stream()
+        .map(dependency -> new DependencyExporterModel(dependency))
+        .collect(Collectors.toSet());
+
+    Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    try {
+      LOG.info("Exporting dependencies to JSON at " + Paths.get(filePath).toAbsolutePath());
+      gson.toJson(dependencyModels, Files.newBufferedWriter(Paths.get(filePath), StandardCharsets.UTF_8));
+    } catch (IOException e) {
+      throw new ExporterException(e);
+    }
+  }
+}

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/exporter/JsonDependencyExporter.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/exporter/JsonDependencyExporter.java
@@ -2,6 +2,7 @@ package com.uber.okbuck.core.dependency.exporter;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.uber.okbuck.extension.ExportDependenciesExtension;
 import org.gradle.api.artifacts.ExternalDependency;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,17 +18,15 @@ public class JsonDependencyExporter implements DependencyExporter {
 
   private static final Logger LOG = LoggerFactory.getLogger(JsonDependencyExporter.class);
 
-  private final String filePath;
-  private final boolean enable;
+  private final ExportDependenciesExtension exportDependenciesExtension;
 
-  public JsonDependencyExporter(String filePath, boolean enable) {
-    this.filePath = filePath;
-    this.enable = enable;
+  public JsonDependencyExporter(ExportDependenciesExtension exportDependenciesExtension) {
+    this.exportDependenciesExtension = exportDependenciesExtension;
   }
 
   @Override
   public void export(Set<ExternalDependency> dependencies) {
-    if (!enable) {
+    if (!exportDependenciesExtension.isEnabled()) {
       LOG.info("Exporting dependencies is disabled");
       return;
     }
@@ -38,8 +37,9 @@ public class JsonDependencyExporter implements DependencyExporter {
 
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
     try {
-      LOG.info("Exporting dependencies to JSON at " + Paths.get(filePath).toAbsolutePath());
-      gson.toJson(dependencyModels, Files.newBufferedWriter(Paths.get(filePath), StandardCharsets.UTF_8));
+      LOG.info("Exporting dependencies to JSON at " + exportDependenciesExtension.getFile());
+      gson.toJson(dependencyModels,
+          Files.newBufferedWriter(Paths.get(exportDependenciesExtension.getFile()), StandardCharsets.UTF_8));
     } catch (IOException e) {
       throw new ExporterException(e);
     }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/exporter/JsonDependencyExporter.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/exporter/JsonDependencyExporter.java
@@ -7,6 +7,7 @@ import org.gradle.api.artifacts.ExternalDependency;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -31,15 +32,17 @@ public class JsonDependencyExporter implements DependencyExporter {
       return;
     }
 
-    Set<DependencyExporterModel> dependencyModels = dependencies.stream()
-        .map(dependency -> new DependencyExporterModel(dependency))
-        .collect(Collectors.toSet());
+    Set<DependencyExporterModel> dependencyModels =
+        dependencies.stream()
+            .map(dependency -> new DependencyExporterModel(dependency))
+            .collect(Collectors.toSet());
 
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
-    try {
+    try (BufferedWriter writer =
+        Files.newBufferedWriter(
+            Paths.get(exportDependenciesExtension.getFile()), StandardCharsets.UTF_8)) {
       LOG.info("Exporting dependencies to JSON at " + exportDependenciesExtension.getFile());
-      gson.toJson(dependencyModels,
-          Files.newBufferedWriter(Paths.get(exportDependenciesExtension.getFile()), StandardCharsets.UTF_8));
+      gson.toJson(dependencyModels, writer);
     } catch (IOException e) {
       throw new ExporterException(e);
     }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/DependencyManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/DependencyManager.java
@@ -1,8 +1,5 @@
 package com.uber.okbuck.core.manager;
 
-import static com.uber.okbuck.core.dependency.OResolvedDependency.AAR;
-import static com.uber.okbuck.core.dependency.OResolvedDependency.JAR;
-
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -22,7 +19,6 @@ import com.uber.okbuck.core.dependency.LocalOExternalDependency;
 import com.uber.okbuck.core.dependency.OExternalDependency;
 import com.uber.okbuck.core.dependency.VersionlessDependency;
 import com.uber.okbuck.core.dependency.exporter.DependencyExporter;
-import com.uber.okbuck.core.dependency.exporter.JsonDependencyExporter;
 import com.uber.okbuck.core.model.base.Scope;
 import com.uber.okbuck.core.util.FileUtil;
 import com.uber.okbuck.core.util.ProjectCache;
@@ -32,10 +28,17 @@ import com.uber.okbuck.extension.JetifierExtension;
 import com.uber.okbuck.extension.OkBuckExtension;
 import com.uber.okbuck.template.common.BazelFunctionRule;
 import com.uber.okbuck.template.core.Rule;
+import org.apache.commons.io.FileUtils;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ExternalDependency;
+import org.gradle.api.artifacts.ResolvedConfiguration;
+import org.gradle.api.artifacts.ResolvedDependency;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -46,18 +49,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.gradle.api.Project;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.ExternalDependency;
-import org.gradle.api.artifacts.ResolvedConfiguration;
-import org.gradle.api.artifacts.ResolvedDependency;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import static com.uber.okbuck.core.dependency.OResolvedDependency.AAR;
+import static com.uber.okbuck.core.dependency.OResolvedDependency.JAR;
 
 public class DependencyManager {
+
   private final Project project;
   private final ExternalDependenciesExtension externalDependenciesExtension;
   private final JetifierExtension jetifierExtension;
@@ -75,7 +72,8 @@ public class DependencyManager {
   private final DependencyExporter dependencyExporter;
 
   public DependencyManager(
-      Project rootProject, OkBuckExtension okBuckExtension, BuckFileManager buckFileManager, DependencyExporter dependencyExporter) {
+      Project rootProject, OkBuckExtension okBuckExtension, BuckFileManager buckFileManager,
+      DependencyExporter dependencyExporter) {
 
     this.project = rootProject;
     this.externalDependenciesExtension = okBuckExtension.getExternalDependenciesExtension();

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/DependencyManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/DependencyManager.java
@@ -104,8 +104,6 @@ public class DependencyManager {
       return;
     }
 
-    dependencyExporter.export(rawDependencies);
-
     Map<String, List<ExternalDependency>> rawDepsMap =
         rawDependencies
             .stream()
@@ -153,6 +151,8 @@ public class DependencyManager {
   }
 
   public void finalizeDependencies(OkBuckExtension okBuckExtension) {
+    dependencyExporter.export(rawDependencies);
+
     Map<VersionlessDependency, Collection<OExternalDependency>> filteredDependencyMap =
         filterDependencies();
 

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
@@ -224,19 +224,4 @@ public final class ProjectUtil {
         && ImmutableList.of(JAR, AAR)
             .contains(FilenameUtils.getExtension(dependencyFile.getName()));
   }
-
-  public static boolean getPropertyAsBoolean(Project project, String propertyName){
-    if(project.hasProperty(propertyName)){
-      return Boolean.parseBoolean((String)project.getProperties().get(propertyName));
-    }
-    return false;
-  }
-
-  @Nullable
-  public static String getPropertyAsString(Project project, String propertyName, String defaultValue){
-    if(project.hasProperty(propertyName)){
-      return (String)project.getProperties().get(propertyName);
-    }
-    return defaultValue;
-  }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/util/ProjectUtil.java
@@ -224,4 +224,19 @@ public final class ProjectUtil {
         && ImmutableList.of(JAR, AAR)
             .contains(FilenameUtils.getExtension(dependencyFile.getName()));
   }
+
+  public static boolean getPropertyAsBoolean(Project project, String propertyName){
+    if(project.hasProperty(propertyName)){
+      return Boolean.parseBoolean((String)project.getProperties().get(propertyName));
+    }
+    return false;
+  }
+
+  @Nullable
+  public static String getPropertyAsString(Project project, String propertyName, String defaultValue){
+    if(project.hasProperty(propertyName)){
+      return (String)project.getProperties().get(propertyName);
+    }
+    return defaultValue;
+  }
 }

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/ExportDependenciesExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/ExportDependenciesExtension.java
@@ -1,0 +1,30 @@
+package com.uber.okbuck.extension;
+
+import org.gradle.api.Project;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+
+import java.nio.file.Paths;
+
+public class ExportDependenciesExtension {
+
+  @Input private final boolean enabled = false;
+
+  @Input
+  @Optional
+  private final String file = ".okbuck/raw-deps";
+
+  private String projectRoot = "";
+
+  public ExportDependenciesExtension(Project project) {
+    projectRoot = project.getProjectDir().getAbsolutePath();
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public String getFile() {
+    return Paths.get(projectRoot, file).toString();
+  }
+}

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/ExportDependenciesExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/ExportDependenciesExtension.java
@@ -7,14 +7,10 @@ import org.gradle.api.tasks.Optional;
 import java.nio.file.Paths;
 
 public class ExportDependenciesExtension {
+  @Input private boolean enabled = false;
+  @Input @Optional private String file = ".okbuck/raw-deps";
 
-  @Input private final boolean enabled = false;
-
-  @Input
-  @Optional
-  private final String file = ".okbuck/raw-deps";
-
-  private String projectRoot = "";
+  private final String projectRoot;
 
   public ExportDependenciesExtension(Project project) {
     projectRoot = project.getProjectDir().getAbsolutePath();

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
@@ -1,19 +1,19 @@
 package com.uber.okbuck.extension;
 
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
+
+import javax.annotation.Nullable;
 import java.io.File;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
-import org.gradle.api.Action;
-import org.gradle.api.Project;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 
 @SuppressWarnings("unused")
 public class OkBuckExtension {
@@ -95,8 +95,7 @@ public class OkBuckExtension {
   @Input public boolean legacyAnnotationProcessorSupport = true;
 
   /** The prebuilt buck binary to use */
-  @Input
-  @Optional
+  @Input @Optional
   public String buckBinary = DEFAULT_BUCK_BINARY_REPO + ":" + DEFAULT_BUCK_BINARY_SHA + "@pex";
 
   /** The prebuilt buck binary to use with java 11 */
@@ -104,27 +103,26 @@ public class OkBuckExtension {
   public String buckBinaryJava11 =
       DEFAULT_BUCK_BINARY_REPO + ":" + DEFAULT_BUCK_BINARY_SHA + ":java11@pex";
 
-  @Internal private Project project;
-  @Internal private WrapperExtension wrapperExtension = new WrapperExtension();
-  @Internal private KotlinExtension kotlinExtension;
-  @Internal private ScalaExtension scalaExtension = new ScalaExtension();
-  @Internal private IntellijExtension intellijExtension = new IntellijExtension();
-  @Internal
-  private ExperimentalExtension experimentalExtension = new ExperimentalExtension();
-  @Internal private TestExtension testExtension = new TestExtension();
-  @Internal private TransformExtension transformExtension = new TransformExtension();
-  @Internal private LintExtension lintExtension;
-  @Internal private JetifierExtension jetifierExtension;
-  @Internal
-  private ExternalDependenciesExtension externalDependenciesExtension =
-      new ExternalDependenciesExtension();
-  @Internal private VisibilityExtension visibilityExtension = new VisibilityExtension();
-  @Internal private RuleOverridesExtension ruleOverridesExtension;
+  @Internal private final WrapperExtension wrapperExtension = new WrapperExtension();
+  @Internal private final KotlinExtension kotlinExtension;
+  @Internal private final ScalaExtension scalaExtension = new ScalaExtension();
+  @Internal private final IntellijExtension intellijExtension = new IntellijExtension();
+  @Internal private final ExperimentalExtension experimentalExtension = new ExperimentalExtension();
+  @Internal private final TestExtension testExtension = new TestExtension();
+  @Internal private final TransformExtension transformExtension = new TransformExtension();
+  @Internal private final LintExtension lintExtension;
+  @Internal private final JetifierExtension jetifierExtension;
 
-  @Internal private ExportDependenciesExtension exportDependenciesExtension;
+  @Internal
+  private final ExternalDependenciesExtension externalDependenciesExtension =
+      new ExternalDependenciesExtension();
+
+  @Internal private final VisibilityExtension visibilityExtension = new VisibilityExtension();
+  @Internal private final RuleOverridesExtension ruleOverridesExtension;
+
+  @Internal private final ExportDependenciesExtension exportDependenciesExtension;
 
   public OkBuckExtension(Project project) {
-    this.project = project;
     buckProjects = project.getSubprojects();
     kotlinExtension = new KotlinExtension(project);
     lintExtension = new LintExtension(project);

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/OkBuckExtension.java
@@ -1,6 +1,7 @@
 package com.uber.okbuck.extension;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -12,7 +13,6 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 
 @SuppressWarnings("unused")
@@ -104,6 +104,7 @@ public class OkBuckExtension {
   public String buckBinaryJava11 =
       DEFAULT_BUCK_BINARY_REPO + ":" + DEFAULT_BUCK_BINARY_SHA + ":java11@pex";
 
+  @Internal private Project project;
   @Internal private WrapperExtension wrapperExtension = new WrapperExtension();
   @Internal private KotlinExtension kotlinExtension;
   @Internal private ScalaExtension scalaExtension = new ScalaExtension();
@@ -120,12 +121,16 @@ public class OkBuckExtension {
   @Internal private VisibilityExtension visibilityExtension = new VisibilityExtension();
   @Internal private RuleOverridesExtension ruleOverridesExtension;
 
+  @Internal private ExportDependenciesExtension exportDependenciesExtension;
+
   public OkBuckExtension(Project project) {
+    this.project = project;
     buckProjects = project.getSubprojects();
     kotlinExtension = new KotlinExtension(project);
     lintExtension = new LintExtension(project);
     jetifierExtension = new JetifierExtension(project);
     ruleOverridesExtension = new RuleOverridesExtension(project);
+    exportDependenciesExtension = new ExportDependenciesExtension(project);
   }
 
   public void wrapper(Action<WrapperExtension> container) {
@@ -319,5 +324,13 @@ public class OkBuckExtension {
 
   public boolean isLegacyAnnotationProcessorSupport() {
     return legacyAnnotationProcessorSupport;
+  }
+
+  public void exportDependencies(Action<ExportDependenciesExtension> container) {
+    container.execute(exportDependenciesExtension);
+  }
+
+  public ExportDependenciesExtension getExportDependenciesExtension() {
+    return exportDependenciesExtension;
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to okbuck. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:  Add support for exporting raw dependencies

plugin can accept the following configuration

```
{
     okbuck {
            ...
           exportDependencies { enabled = false, file = ".okbuck/raw-deps" }
           ...
}
```

Supports exporting raw dependencies in JSON format.

```
./gradlew okbuck
```

Example exported json snippet:

```
[
  {
    "name": "hadoop-aws",
    "version": "2.8.2",
    "group": "org.apache.hadoop",
    "force": false,
    "excludeRules": [
      "javax.servlet",
      "org.mortbay.jetty",
      "slf4j-log4j12"
    ],
    "transitive": true
  },
 
  ....
]
```

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:
