### PR TITLE
Delete tmp file and .bak file for android lint runs

### DIFF
--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/OkbuckTargets.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/OkbuckTargets.rocker.raw
@@ -187,7 +187,9 @@ def okbuck_lint(
     cmd += "--fullpath "
 
     cmd += "{} `dirname {}` >$LOGFILE 2>/dev/null; ".format(" ".join(lint_options), toLocation(manifest))
-    cmd += "rm $CP_FILE; "
+    
+    #Delete tmp file and tmp.bak file
+    cmd += "rm $CP_FILE*; "
 
     native.genrule(
         name = name,


### PR DESCRIPTION
Android Lint has always had a leftover tmp.bak file after it's run which add up over time. After moving this to buck-out's $TMP, this was obvious.