### PR TITLE
Update signing certificate for Sonatype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@
 
   ### Version 0.54.1
 * Clean up leftover tmp file for Android Lint genrule
+
+  ### Version 0.54.2
+* Signing certificate is invalid, replacement release with new signature.
+* No other code changes

--- a/README-zh.md
+++ b/README-zh.md
@@ -9,7 +9,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.uber:okbuck:0.54.1'
+        classpath 'com.uber:okbuck:0.54.2'
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.uber:okbuck:0.54.1'
+        classpath 'com.uber:okbuck:0.54.2'
     }
 }
 

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.uber
-VERSION_NAME=0.54.2
+VERSION_NAME=0.54.3-SNAPSHOT
 POM_DESCRIPTION=A Gradle plugin that lets developers utilize the Buck build system on a Gradle project
 POM_URL=https://github.com/uber/okbuck/
 POM_SCM_URL=https://github.com/uber/okbuck/

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.uber
-VERSION_NAME=0.54.2-SNAPSHOT
+VERSION_NAME=0.54.2
 POM_DESCRIPTION=A Gradle plugin that lets developers utilize the Buck build system on a Gradle project
 POM_URL=https://github.com/uber/okbuck/
 POM_SCM_URL=https://github.com/uber/okbuck/

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
 android.useAndroidX=true
 android.enableJetifier=true
-org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
The Uber open source signing certificate was accidentally compromised.  That old certificate has been invalidated, and a new certificate was generated.  This updates the signed code in the Sonatype repository (maven).

No other code changes are in this release.