### PR TITLE
Bumping robolectric to 4.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,5 @@
 
 ### Version 0.54.3
 * Added support for Android API 32, 33, and 34
+* Bump robolectric to 4.8.2
+* Bump pre-instrumented JARs to i4

--- a/README-zh.md
+++ b/README-zh.md
@@ -9,7 +9,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.uber:okbuck:0.54.1'
+        classpath 'com.uber:okbuck:0.54.2'
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.uber:okbuck:0.54.1'
+        classpath 'com.uber:okbuck:0.54.2'
     }
 }
 

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.uber
-VERSION_NAME=0.54.2-SNAPSHOT
+VERSION_NAME=0.54.3-SNAPSHOT
 POM_DESCRIPTION=A Gradle plugin that lets developers utilize the Buck build system on a Gradle project
 POM_URL=https://github.com/uber/okbuck/
 POM_SCM_URL=https://github.com/uber/okbuck/

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/TestExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/TestExtension.java
@@ -18,7 +18,7 @@ public class TestExtension {
    * Hardcoded in Robolectric
    * https://github.com/robolectric/robolectric/blob/master/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java#L50
    */
-  public String robolectricPreinstrumentedVersion = "i3";
+  public String robolectricPreinstrumentedVersion = "i4";
 
   /** Enable generation of espresso test rules. */
   public boolean espresso = false;

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -132,7 +132,7 @@ def test = [
         junit         : "junit:junit:4.13.2",
         kotlinTest    : "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}",
         mockito       : "org.mockito:mockito-core:3.8.0",
-        robolectric   : "org.robolectric:robolectric:4.7.3",
+        robolectric   : "org.robolectric:robolectric:4.8.2",
         scalaTest     : "org.scalatest:scalatest_sjs1_2.13:3.2.0",
         scalaTestJunit: "org.scalatestplus:junit-4-12_2.13:3.2.2.0",
         testExt       : "androidx.test.ext:junit:1.1.2-rc01",


### PR DESCRIPTION
**Description**:
- bumps robo to 4.8.2
- bumps pre-instrumented jars to i4
- fixes previous squash version snafus
