### PR TITLE
Update actions used in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,18 @@ jobs:
       SKIP_OKBUCK: true
       EXTRA_OKBUCK_ARGS: "--quiet --stacktrace"
       EXTRA_BUCK_ARGS: "-v 0"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         build_cmd: [build, lint, test]
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Install JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
+          distribution: temurin
       - name: Run ${{ matrix.build_cmd }}
         run: ./tooling/ci/build_cmd.sh ${{ matrix.build_cmd }}
       - name: Upload snapshot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
         with:
           java-version: 11
           distribution: temurin
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
       - name: Run ${{ matrix.build_cmd }}
         run: ./tooling/ci/build_cmd.sh ${{ matrix.build_cmd }}
       - name: Upload snapshot

--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -8,14 +8,15 @@ on:
 jobs:
   build:
     name: Run Fossa License Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Install JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
+          distribution: temurin
       - name: Run Fossa License Check
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}

--- a/README-zh.md
+++ b/README-zh.md
@@ -45,7 +45,6 @@ okbuck {
                     '^com/uber/okbuck/example/BuildConfig^',
                     '^android/support/multidex/',
                     '^com/facebook/buck/android/support/exopackage/',
-                    '^com/github/promeg/xlog_android/lib/XLogConfig^',
                     '^com/squareup/leakcanary/LeakCanary^',
             ]
     ]

--- a/Usage.md
+++ b/Usage.md
@@ -15,7 +15,6 @@ okbuck {
                     '^com/uber/okbuck/example/BuildConfig^',
                     '^android/support/multidex/',
                     '^com/facebook/buck/android/support/exopackage/',
-                    '^com/github/promeg/xlog_android/lib/XLogConfig^',
                     '^com/squareup/leakcanary/LeakCanary^',
             ]
     ]

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
         buildConfigField "int", "EXOPACKAGE_FLAGS", "0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
-        // If app doesn"t specify dimensions, use missingDimensionStrategy
+        // If app doesn't specify dimensions, use missingDimensionStrategy
         // https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html#resolve_matching_errors
         missingDimensionStrategy "tier", "free", "paid"
     }
@@ -60,7 +60,6 @@ dependencies {
     implementation(name: "rxscreenshotdetector-1.2.0", ext: "aar")
     implementation deps.external.rxjava
     implementation deps.external.rxandroid
-    implementation deps.external.rxPermissions
     implementation deps.external.butterKnife
 
     implementation deps.androidx.multidex

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,6 @@ android {
         applicationId "com.uber.okbuck.app"
         multiDexEnabled true
         buildConfigField "boolean", "CAN_JUMP", "true"
-        buildConfigField "boolean", "XLOG_ENABLED", "true"
         buildConfigField "int", "EXOPACKAGE_FLAGS", "0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
@@ -68,7 +67,6 @@ dependencies {
     implementation deps.androidx.recyclerView
 
     implementation deps.external.leakCanary
-    implementation deps.external.xlogAndroidIdle
 
     implementation project(":libraries:emptylibrary")
     implementation project(":libraries:kotlinandroidlibrary")

--- a/app/src/main/java/com/uber/okbuck/example/MainActivity.java
+++ b/app/src/main/java/com/uber/okbuck/example/MainActivity.java
@@ -13,7 +13,6 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;
 import com.github.piasy.rxscreenshotdetector.RxScreenshotDetector;
-import com.promegu.xlog.base.XLog;
 import com.uber.okbuck.example.common.Calc;
 import com.uber.okbuck.example.common.CalcMonitor;
 import com.uber.okbuck.example.common.IMyAidlInterface;
@@ -28,7 +27,6 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 import javax.inject.Inject;
 
-@XLog
 public class MainActivity extends AppCompatActivity {
   @Inject DummyJavaClass mDummyJavaClass;
   @Inject DummyAndroidClass mDummyAndroidClass;

--- a/app/src/main/java/com/uber/okbuck/example/MyApp.java
+++ b/app/src/main/java/com/uber/okbuck/example/MyApp.java
@@ -3,7 +3,6 @@ package com.uber.okbuck.example;
 import android.app.Application;
 import androidx.appcompat.app.AppCompatDelegate;
 import com.facebook.buck.android.support.exopackage.DefaultApplicationLike;
-import com.github.promeg.xlog_android.lib.XLogConfig;
 
 public class MyApp extends DefaultApplicationLike {
 
@@ -11,17 +10,6 @@ public class MyApp extends DefaultApplicationLike {
     AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
   }
 
-  private final Application mApplication;
-
   public MyApp(Application application) {
-    mApplication = application;
-  }
-
-  @Override
-  public void onCreate() {
-    super.onCreate();
-    if (BuildConfig.XLOG_ENABLED) {
-      XLogConfig.config(XLogConfig.newConfigBuilder(mApplication).build());
-    }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,6 @@ okbuck {
                     "^com/uber/okbuck/example/BuildConfig^",
                     "^androidx/multidex/",
                     "^com/facebook/buck/android/support/exopackage/",
-                    "^com/github/promeg/xlog_android/lib/XLogConfig^",
                     "^com/squareup/leakcanary/LeakCanary^",
                     "^com/uber/okbuck/example/common/Calc^",
                     "^com/uber/okbuck/example/common/BuildConfig^",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -93,7 +93,6 @@ def external = [
         sqldelight      : "com.squareup.sqldelight:android-driver:${versions.sqldelight}",
         rxandroid       : "io.reactivex.rxjava2:rxandroid:2.1.1",
         rxjava          : "io.reactivex.rxjava2:rxjava:2.2.21",
-        rxPermissions   : "com.tbruyelle.rxpermissions2:rxpermissions:0.9.5",
         sqlite          : "com.pushtorefresh.storio3:sqlite:3.0.0",
         xlogAndroidIdle : "com.github.promeg:xlog-android-idle:2.1.1",
         avroIpc         : "org.apache.avro:avro-ipc:${versions.avro}",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -94,7 +94,6 @@ def external = [
         rxandroid       : "io.reactivex.rxjava2:rxandroid:2.1.1",
         rxjava          : "io.reactivex.rxjava2:rxjava:2.2.21",
         sqlite          : "com.pushtorefresh.storio3:sqlite:3.0.0",
-        xlogAndroidIdle : "com.github.promeg:xlog-android-idle:2.1.1",
         avroIpc         : "org.apache.avro:avro-ipc:${versions.avro}",
         avroIpcTests    : "org.apache.avro:avro-ipc:${versions.avro}:tests",
         saxon           : "net.sf.saxon:Saxon-HE:10.3",


### PR DESCRIPTION
**Description**

- Update the runner image to `ubuntu-24.04`. `ubuntu-20.04` is now deprecated: https://github.com/actions/runner-images/issues/11101
- Update `actions/checkout` to v4.
- Update `actions/setup-java` to v4 and set the distribution to `temurin`.

**Note**

- It's possible to use `ubuntu-latest` instead of `ubuntu-24.04`. Let me know which option you prefer.
- `actions/setup-java` supports a [wide range of distributions](https://github.com/actions/setup-java#supported-distributions). Let me know if you'd prefer to use something else than `temurin`.