### PR TITLE
Add support for setting 'labels' in prebuilt rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Bug fix to handle export dependencies file path correctly.
 
 ### Version 0.53.3
-* Add configuration cleanCacheDir to conditionally delete the cache directory or 
+* Add configuration cleanCacheDir to conditionally delete the cache directory or
   just the existing dependency rules files
 
 ### Version 0.54.0
@@ -27,3 +27,16 @@
 
 ### Version 0.54.4
 * Added support for using Android Lint 31.3+
+
+### Version 0.54.5
+* Added `labelsMap` configuration to `externalDependencies` block for adding custom labels to prebuilt dependency rules
+* Migrated Robolectric's deprecated code to recommended alternatives:
+  - Added `:libraries:robolectric-base` to Gradle modules
+  - Added missing jUnit dependency to robolectric-base
+  - Replaced deprecated `getAppManifest()` with `getManifestFactory()` and created `BuckManifestFactory`
+* Updated GitHub Actions workflows:
+  - Updated runner image to `ubuntu-24.04` (ubuntu-20.04 is deprecated)
+  - Updated `actions/checkout` to v4
+  - Updated `actions/setup-java` to v4 with temurin distribution
+  - Removed rxPermissions and XLog dependencies
+  - Updated to Python 3.8

--- a/Usage.md
+++ b/Usage.md
@@ -61,10 +61,20 @@ okbuck {
     experimental {
         transform = true
     }
-    
+
     externalDependencies {
         cache = "3rdparty/jvm"
         cleanCacheDir = true
+        labelsMap = [
+            "com.example:library:1.0.0": [
+                "category=utility",
+                "license=apache-2.0"
+            ],
+            "junit:junit:4.13.2": [
+                "category=testing",
+                "test_framework=true"
+            ]
+        ]
     }
 }
 
@@ -85,6 +95,10 @@ please read the [Exopackage wiki](https://github.com/uber/okbuck/wiki/Exopackage
 +  `extraBuckOpts` provides a hook to add additional configuration options for buck [android_binary](https://buckbuild.com/rule/android_binary.html) rules
 +  `wrapper` is used to configure creation of the buck wrapper script.
  - `repo` - The git url of any custom buck fork. Default is none.
++  `externalDependencies` block configures external dependency resolution and generation:
++ - `cache` - Specifies the folder where external dependency rules are generated. Default is `.okbuck/ext`
++ - `cleanCacheDir` - Whether to delete the cache directory before generating dependency rules. Default is `true`
++ - `labelsMap` - Map of dependency coordinates to labels for prebuilt rules. Keys are Maven coordinates in format `"groupId:artifactId:version"`, values are lists of arbitrary strings. An example usecase could be to tag all test dependencies to easily be able to query them.
 + The keys used to configure various options can be for
  - All buildTypes and flavors i.e `app`
  - All buildTypes of a particular flavor i.e 'appDemo'

--- a/build.gradle
+++ b/build.gradle
@@ -237,6 +237,17 @@ okbuck {
             "autoValueGson",
             "autoValueParcel",
         ]
+        // Example: Add labels for specific dependencies
+        labelsMap = [
+            "com.example:library:1.0.0": [
+                "category=utility",
+                "license=apache-2.0"
+            ],
+            "junit:junit:4.13.2": [
+                "category=testing",
+                "test_framework=true"
+            ]
+        ]
     }
 
     dependencies {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     annotationProcessor deps.apt.autoValue
     annotationProcessor deps.build.nullaway
 
+    testAnnotationProcessor deps.build.nullaway
+
     errorprone deps.build.erroproneCompiler
     errorproneJavac deps.build.errorproneJavac
 
@@ -60,6 +62,7 @@ dependencies {
     implementation deps.external.gson
 
     testImplementation deps.test.junit
+    testImplementation deps.test.mockito
 }
 
 rocker {

--- a/buildSrc/src/main/java/com/uber/okbuck/composer/java/PrebuiltRuleComposer.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/composer/java/PrebuiltRuleComposer.java
@@ -11,13 +11,26 @@ import com.uber.okbuck.core.model.base.RuleType;
 import com.uber.okbuck.template.core.Rule;
 import com.uber.okbuck.template.java.Prebuilt;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 public class PrebuiltRuleComposer extends JvmBuckRuleComposer {
 
   private PrebuiltRuleComposer() {}
+
+  // Visibile for testing
+  static ImmutableSet<String> getLabels(OExternalDependency dependency, @Nullable Map<String, List<String>> labelsMap) {
+    List<String> labels = (labelsMap == null)
+      ? Collections.emptyList()
+      : labelsMap.getOrDefault(dependency.getMavenCoordsForValidation(), Collections.emptyList());
+
+    return labels == null ? ImmutableSet.of() : ImmutableSet.copyOf(labels);
+  }
 
   /**
    * @param dependencies External Dependencies whose rule needs to be created
@@ -26,6 +39,11 @@ public class PrebuiltRuleComposer extends JvmBuckRuleComposer {
   @SuppressWarnings("NullAway")
   public static List<Rule> compose(
       Collection<OExternalDependency> dependencies, HashMap<String, String> shaSum256) {
+    return compose(dependencies, shaSum256, null);
+  }
+
+  public static List<Rule> compose(
+      Collection<OExternalDependency> dependencies, HashMap<String, String> shaSum256, Map<String, List<String>> labelsMap) {
     return dependencies
         .stream()
         .peek(
@@ -57,6 +75,8 @@ public class PrebuiltRuleComposer extends JvmBuckRuleComposer {
                             Preconditions.checkNotNull(shaSum256.get(sourcesSha256Key));
                         rule.sourcesSha256(sourcesSha256);
                       });
+
+              rule.labels(getLabels(dependency, labelsMap));
 
               rule.ruleType(RuleType.PREBUILT.getBuckName())
                   .deps(external(dependency.getDeps()))

--- a/buildSrc/src/main/java/com/uber/okbuck/core/manager/DependencyManager.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/manager/DependencyManager.java
@@ -438,8 +438,11 @@ public class DependencyManager {
 
           ImmutableList.Builder<Rule> rulesBuilder = ImmutableList.builder();
           rulesBuilder.addAll(LocalPrebuiltRuleComposer.compose(localPrebuiltDependencies.build()));
+
+          Map<String, List<String>> labelsMap = externalDependenciesExtension.getLabelsMap();
+
           rulesBuilder.addAll(
-              PrebuiltRuleComposer.compose(prebuiltDependencies.build(), sha256Cache));
+              PrebuiltRuleComposer.compose(prebuiltDependencies.build(), sha256Cache, labelsMap));
           rulesBuilder.addAll(
               HttpFileRuleComposer.compose(httpFileDependencies.build(), sha256Cache));
 

--- a/buildSrc/src/main/java/com/uber/okbuck/extension/ExternalDependenciesExtension.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/extension/ExternalDependenciesExtension.java
@@ -73,6 +73,9 @@ public class ExternalDependenciesExtension {
   /** Set the path to the sha256sum caches of external dependency artifacts */
   @Input private String sha256Cache = OkBuckGradlePlugin.DEFAULT_OKBUCK_SHA256;
 
+  /** Map of dependency coordinates to labels for prebuilt rules */
+  @Input private Map<String, List<String>> labelsMap = new HashMap<>();
+
   @Nullable private Set<VersionlessDependency> allowAllVersionsSet;
 
   public ExternalDependenciesExtension() {}
@@ -182,5 +185,9 @@ public class ExternalDependenciesExtension {
 
   public boolean shouldCleanCacheDir() {
     return cleanCacheDir;
+  }
+
+  public Map<String, List<String>> getLabelsMap() {
+    return labelsMap;
   }
 }

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/config/OkbuckPrebuilt.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/config/OkbuckPrebuilt.rocker.raw
@@ -13,7 +13,8 @@ def @(okbuckPrebuiltRule)(
         deps = None,
         enable_jetifier = False,
         first_level = False,
-        testonly = False):
+        testonly = False,
+        labels = None):
     if deps == None:
         deps = []
 
@@ -64,6 +65,7 @@ def @(okbuckPrebuiltRule)(
             deps = deps,
             visibility = visibility,
             enable_jetifier = enable_jetifier,
+            labels = labels,
         )
     elif prebuilt_type == "jar":
         @(prebuiltJarRule)(
@@ -74,6 +76,7 @@ def @(okbuckPrebuiltRule)(
             deps = deps,
             visibility = visibility,
             enable_jetifier = enable_jetifier,
+            labels = labels,
         )
     else:
         fail("okbuck_prebuilt not supported for type {}".format(prebuilt_type))

--- a/buildSrc/src/main/rocker/com/uber/okbuck/template/java/Prebuilt.rocker.raw
+++ b/buildSrc/src/main/rocker/com/uber/okbuck/template/java/Prebuilt.rocker.raw
@@ -14,6 +14,13 @@ boolean firstLevel,
 @if (firstLevel) {
     first_level = True,
 }
+@if (valid(labels)) {
+    labels = [
+    @for (label : sorted(labels)) {
+        "@label",
+    }
+    ],
+}
     maven_coords = "@mavenCoords",
     sha256 = "@sha256",
 @if (valid(sourcesSha256)) {

--- a/buildSrc/src/test/java/com/uber/okbuck/composer/java/PrebuiltRuleComposerTest.java
+++ b/buildSrc/src/test/java/com/uber/okbuck/composer/java/PrebuiltRuleComposerTest.java
@@ -1,0 +1,118 @@
+package com.uber.okbuck.composer.java;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.uber.okbuck.core.dependency.OExternalDependency;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+public class PrebuiltRuleComposerTest {
+
+  @Test
+  public void getLabels_withValidLabelsMap_returnsLabels() {
+    // Arrange
+    OExternalDependency dependency = mock(OExternalDependency.class);
+    Map<String, List<String>> labelsMap = new HashMap<>();
+    List<String> expectedLabels = new ArrayList<>();
+    expectedLabels.add("test_label=value1,value2");
+    labelsMap.put("com.example:test-artifact:1.0.0", expectedLabels);
+
+    when(dependency.getMavenCoordsForValidation()).thenReturn("com.example:test-artifact:1.0.0");
+
+    // Act
+    Set<String> result = PrebuiltRuleComposer.getLabels(dependency, labelsMap);
+
+    // Assert
+    assertNotNull(result);
+    assertEquals(expectedLabels.size(), result.size());
+    assertTrue(result.contains("test_label=value1,value2"));
+  }
+
+  @Test
+  public void getLabels_withNullLabelsMap_returnsEmptySet() {
+    // Arrange
+    OExternalDependency dependency = mock(OExternalDependency.class);
+
+    // Act
+    Set<String> result = PrebuiltRuleComposer.getLabels(dependency, null);
+
+    // Assert
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void getLabels_withEmptyLabelsMap_returnsEmptySet() {
+    // Arrange
+    OExternalDependency dependency = mock(OExternalDependency.class);
+    Map<String, List<String>> emptyLabelsMap = new HashMap<>();
+
+    // Act
+    Set<String> result = PrebuiltRuleComposer.getLabels(dependency, emptyLabelsMap);
+
+    // Assert
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void getLabels_withMissingKey_returnsEmptySet() {
+    // Arrange
+    OExternalDependency dependency = mock(OExternalDependency.class);
+    Map<String, List<String>> labelsMap = new HashMap<>();
+    List<String> labels = new ArrayList<>();
+    labels.add("other_label=other_value");
+    labelsMap.put("com.other:other-artifact:2.0.0", labels);
+
+    when(dependency.getMavenCoordsForValidation()).thenReturn("com.example:test-artifact:1.0.0");
+
+    // Act
+    Set<String> result = PrebuiltRuleComposer.getLabels(dependency, labelsMap);
+
+    // Assert
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void getLabels_withNullValue_returnsEmptySet() {
+    // Arrange
+    OExternalDependency dependency = mock(OExternalDependency.class);
+    Map<String, List<String>> labelsMap = new HashMap<>();
+    labelsMap.put("com.example:test-artifact:1.0.0", null);
+
+    when(dependency.getMavenCoordsForValidation()).thenReturn("com.example:test-artifact:1.0.0");
+
+    // Act
+    Set<String> result = PrebuiltRuleComposer.getLabels(dependency, labelsMap);
+
+    // Assert
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void getLabels_withEmptyValue_returnsEmptySet() {
+    // Arrange
+    OExternalDependency dependency = mock(OExternalDependency.class);
+    Map<String, List<String>> labelsMap = new HashMap<>();
+    labelsMap.put("com.example:test-artifact:1.0.0", new ArrayList<>());
+
+    when(dependency.getMavenCoordsForValidation()).thenReturn("com.example:test-artifact:1.0.0");
+
+    // Act
+    Set<String> result = PrebuiltRuleComposer.getLabels(dependency, labelsMap);
+
+    // Assert
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+}


### PR DESCRIPTION
In this commit, we add support for setting the 'labels' field to the template for the prebuilt macros. This allows for setting specific lables on dependencies, which can be used for validation and querying logic.

<!--
Thank you for contributing to okbuck. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
There are situations where we may want to make decisions on specific sets of dependencies with a macro, or even make specific sets of dependencies easier to query. 'labels' is already Buck's way of adding arbitrary metadata to a rule and can be leveraged here. 

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:
None
